### PR TITLE
Track portfolio images with Git LFS and switch site to local assets

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+assets/*.jpg filter=lfs diff=lfs merge=lfs -text
+assets/*.png filter=lfs diff=lfs merge=lfs -text

--- a/amazing-eternals.html
+++ b/amazing-eternals.html
@@ -7,97 +7,79 @@
     <link rel="stylesheet" href="style.css" />
 </head>
 <body>
-    <header>
-        <nav class="top-nav">
-            <a href="index.html#projects" class="nav-item">PROJECTS</a>
-            <div class="nav-title">
-                SHERVIN GHAZAZANI – TECHNICAL GAME DESIGNER
+    <header class="site-header">
+        <div class="page">
+            <div class="nav-grid">
+                <div class="nav-left">
+                    <a href="index.html#projects"><b><span class="caption">Projects</span></b></a>
+                </div>
+                <div class="nav-center">
+                    <b><span class="caption">Shervin Ghazazani - Technical Game Designer</span></b>
+                </div>
+                <div class="nav-right">
+                    <a href="mailto:shervinghazazani@gmail.com"><b><span class="caption">Contact</span></b></a>
+                </div>
             </div>
-            <a href="index.html#contact" class="nav-item">CONTACT</a>
-        </nav>
+            <hr class="rule" />
+        </div>
     </header>
+
     <main class="project-page">
-        <section class="project-content">
-            <h1>Amazing Eternals</h1>
-            <!-- Tagline and year -->
-            <p class="project-tagline">CCG Shooter • 2017</p>
-            <div class="project-media"></div>
-            <p>With a 1970s retro‑pulp era look and feel, The Amazing Eternals takes players on a journey through a multiverse that begins on the starting square of a mystical board game. Players enter a deathmatch while wielding unique decks of cards that offer handy benefits, amazing powers, and fearsome weapons.</p>
-            <p>With timing and resourcefulness, customized decks give players the upper hand in battle both individually and in teams.</p>
-            <p><strong>Notable Mentions:</strong> Won several “best of show” awards from various publications at PAX 2017.</p>
-        </section>
-        <section class="project-screenshots">
-            <div class="screenshot-placeholder"></div>
-            <div class="screenshot-placeholder"></div>
-            <div class="screenshot-placeholder"></div>
-        </section>
-        <section class="project-grid-section">
-            <h2>Other Projects</h2>
-            <div class="project-grid">
-                <a href="omega-strikers.html" class="project">
-                    <div class="project-thumb" style="background-image: url('https://freight.cargo.site/w/100/i/V2548604313848078054190197947345/OmegaStrikersThumbnail.png'); background-size: cover; background-position: center;"></div>
-                    <div class="project-title">Omega Strikers</div>
-                </a>
-                <a href="chivalry-2.html" class="project">
-                    <div class="project-thumb" style="background-image: url('https://freight.cargo.site/w/100/i/J254858422750250841112505662417/Chivalry2Thumbnail.jpg'); background-size: cover; background-position: center;"></div>
-                    <div class="project-title">Chivalry 2</div>
-                </a>
-                <a href="warframe.html" class="project">
-                    <div class="project-thumb" style="background-image: url('https://freight.cargo.site/w/100/i/D2548583997102217360480205978577/WarframeThumbnail.jpg'); background-size: cover; background-position: center;"></div>
-                    <div class="project-title">Warframe</div>
-                </a>
-                <a href="field-1.html" class="project">
-                    <div class="project-thumb" style="background-image: url('https://freight.cargo.site/w/100/i/Z2548583629108119834048360790993/Field1Thumbnail.png'); background-size: cover; background-position: center;"></div>
-                    <div class="project-title">Field‑1</div>
-                </a>
-                <a href="zero-mark.html" class="project">
-                    <div class="project-thumb" style="background-image: url('https://freight.cargo.site/w/100/i/X254858340234224953936842775505/ZeroMarkThumbnail.png'); background-size: cover; background-position: center;"></div>
-                    <div class="project-title">Zero Mark</div>
-                </a>
-                <a href="witchball.html" class="project">
-                    <div class="project-thumb" style="background-image: url('https://freight.cargo.site/w/100/i/K2548580396334667660523149638609/wetwork_thumbnail.png'); background-size: cover; background-position: center;"></div>
-                    <div class="project-title">Witchball</div>
-                </a>
-                <a href="wetwork.html" class="project">
-                    <div class="project-thumb" style="background-image: url('https://freight.cargo.site/w/100/i/K2548580396334667660523149638609/wetwork_thumbnail.png'); background-size: cover; background-position: center;"></div>
-                    <div class="project-title">Wetwork</div>
-                </a>
-                <a href="brutal-arena.html" class="project">
-                    <div class="project-thumb" style="background-image: url('https://freight.cargo.site/w/100/i/A25485818171410110770633735060433/BrutalArenaThumbnail.png'); background-size: cover; background-position: center;"></div>
-                    <div class="project-title">Brutal Arena</div>
-                </a>
-                <a href="index.html" class="project">
-                    <div class="project-thumb placeholder"></div>
-                    <div class="project-title">Back to Home</div>
-                </a>
-            </div>
-        </section>
+        <div class="page">
+            <section class="project-details">
+                <div class="project-meta">
+                    <b>Amazing Eternals</b><br /><br />
+                    <span class="caption">CCG Shooter<br />2017</span>
+                </div>
+                <div class="project-body">
+                    <p>
+                        With a 1970s retro-pulp era look and feel, The Amazing Eternals takes players on a journey through a multiverse that begins on the starting square of a mystical board game. Players enter a deathmatch while wielding unique decks of cards that offer handy benefits, amazing powers, and fearsome weapons. With timing and resourcefulness, customized decks give players the upper hand in battle both individually and in teams.
+                    </p>
+                    <p>
+                        <b>Notable Mentions:</b><br />
+                        Won several "best of show" awards from various publications at PAX 2017
+                    </p>
+                </div>
+            </section>
+            <section class="media-gallery">
+                <img src="assets/TheAmazingEternals.jpg" alt="Amazing Eternals screenshot 1" />
+                <img src="assets/the-amazing-eternals-1_590.jpg" alt="Amazing Eternals screenshot 2" />
+                <img src="assets/vanilla_deck_Page_2.png" alt="Amazing Eternals screenshot 3" />
+                <img src="assets/tumblr_n3udviTCwl1shf3nvo2_500.png" alt="Amazing Eternals screenshot 4" />
+                <img src="assets/tumblr_n3udviTCwl1shf3nvo3_500.png" alt="Amazing Eternals screenshot 5" />
+            </section>
+        </div>
     </main>
-    <footer class="footer">
-        <div class="footer-col">
-            <h3>Shervin Ghazazani</h3>
-            <ul class="contact-list">
-                <li><a href="mailto:shervinghazazani@gmail.com">Email</a></li>
-                <li><a href="#">LinkedIn</a></li>
-                <li><a href="#">Twitter</a></li>
-            </ul>
-        </div>
-        <div class="footer-col">
-            <h3>About Me</h3>
-            <p>
-                Hello and welcome to my portfolio! I'm a game designer at Odyssey
-                Interactive. My work tends to involve zero‑sum game systems,
-                fast‑paced dynamics, and visceral game feel.
-            </p>
-        </div>
-        <div class="footer-col">
-            <h3>Currently Consuming:</h3>
-            <ul>
-                <li>Witchfire (PC)</li>
-                <li>Dead Cells (iOS)</li>
-                <li>The Penguin (HBO)</li>
-                <li>3 Body Problem Trilogy (Audiobook)</li>
-            </ul>
+
+    <footer class="site-footer">
+        <div class="page">
+            <hr class="rule" />
+            <div class="footer-grid">
+                <div>
+                    <h3>Shervin Ghazazani</h3>
+                    <div class="caption footer-links">
+                        <a href="mailto:shervinghazazani@gmail.com">Email</a><br />
+                        <a href="https://www.linkedin.com/in/shervinghazazani/" target="_blank" rel="noreferrer">LinkedIn</a><br />
+                        <a href="https://www.twitter.com/gahzi" target="_blank" rel="noreferrer">Twitter</a>
+                    </div>
+                </div>
+                <div>
+                    <h3>About Me</h3>
+                    <div class="caption">
+                        Hello and welcome to my portfolio!<br /><br />
+                        I’m a game designer at Odyssey Interactive, specializing in competitive systems, fast-paced dynamics, and gameplay that feels immediately impactful.
+                    </div>
+                </div>
+                <div>
+                    <h3>Currently Consuming</h3>
+                    <div class="caption">
+                        - Witchfire (PC)<br />
+                        - Dead Cells (iOS)<br />
+                        - The Penguin (HBO)<br />
+                        - 3 Body Problem Trilogy (Audiobook)
+                    </div>
+                </div>
+            </div>
         </div>
     </footer>
 </body>

--- a/assets/083554_1000.jpg
+++ b/assets/083554_1000.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:36b6865af4234f8c4b313fbe87cb284df5aa55c54443f436eaf853ed08eb9cbf
+size 206449

--- a/assets/2013-05-16-20.33.46.jpg
+++ b/assets/2013-05-16-20.33.46.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f9a3a3fc30f19f8cb3a0b20b21c6ae0aa13503f2e60d161dfa3341f2d0ce27e7
+size 199272

--- a/assets/9o7JLM-l2f4_1000.jpg
+++ b/assets/9o7JLM-l2f4_1000.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2241184f04adecdaa220c0d62d1df668277ebfc5782d266722142e5da8052464
+size 291269

--- a/assets/AimAssist4_1000.png
+++ b/assets/AimAssist4_1000.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f4b19e7e922759151b15308370d96c69d16d66ab919ad10aab1dbb25f50d6289
+size 647003

--- a/assets/BrutalArenaDeath.png
+++ b/assets/BrutalArenaDeath.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9e596a354ececebb52dda217ea5b2ce5b48b0d4abc6a5e84ece0f7f8e0064923
+size 206148

--- a/assets/BrutalArenaGameplay2.png
+++ b/assets/BrutalArenaGameplay2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:496bd051207a7056c364b9dff79ad7eabb18fc3a1a78803fd740480010ce8337
+size 367670

--- a/assets/BrutalArenaStart.png
+++ b/assets/BrutalArenaStart.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e62dc4bd9a91d2173c85156881a9fde5e1d27bf2460d9b20393c9e824b1bbe6c
+size 236575

--- a/assets/BrutalArenaThumbnail.png
+++ b/assets/BrutalArenaThumbnail.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:69c571fff7af502371c63e464d30b137c58e8ca5392fd696af483a76910b925a
+size 42077

--- a/assets/Chivalry-2-13_1000.jpg
+++ b/assets/Chivalry-2-13_1000.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5ec0bdba4245a178d68cc4dea46be32bc0efc628d74b5a826d375bf29473b8db
+size 238258

--- a/assets/Chivalry-2-2021-06-05-23-49-42.mp4-VLC-media-player-6_6_2021-1_37_17-AM_1000.png
+++ b/assets/Chivalry-2-2021-06-05-23-49-42.mp4-VLC-media-player-6_6_2021-1_37_17-AM_1000.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bb913c82b25e58f4c91d64070ba7c075c0f7cd223d63ca54e2bb3bea72f632f4
+size 905442

--- a/assets/Chivalry2Thumbnail.jpg
+++ b/assets/Chivalry2Thumbnail.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:975e1ac0c10969ef3a56bc598e1f8bd584a0c8137e304f7506a95554fcdd1277
+size 22101

--- a/assets/Chivalry2_PAXE_3_1000.jpg
+++ b/assets/Chivalry2_PAXE_3_1000.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d58b620c62313f0bc86bf07e1522983d33d31a5c09cd3d46ea6bec383882516e
+size 394324

--- a/assets/Exploiter-Orb-Fight-Guide-7_700.jpg
+++ b/assets/Exploiter-Orb-Fight-Guide-7_700.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:52536623ac0da86f58f8a752b7866202ed6831aa04f11bc68c2796c6fde5c167
+size 66362

--- a/assets/Field-1AboutScreen.png
+++ b/assets/Field-1AboutScreen.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eb28376a3d8b7276f4a0d8a9256c069ca60096bde3858cd9aa436753abfb7b57
+size 57020

--- a/assets/Field-1DrugScreen.png
+++ b/assets/Field-1DrugScreen.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ef75bb4890c5638fb0ac1ffe2739b75e2b45b44331c447ec42d1ea92619c4cbc
+size 79941

--- a/assets/Field-1Gameplay.png
+++ b/assets/Field-1Gameplay.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:05f44c5e63d54a46c4e9b3a06170bff3af30e66d3d3b59d0d3d16b33080ee553
+size 136401

--- a/assets/Field-1TitleScreen.png
+++ b/assets/Field-1TitleScreen.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:070bd38a93143978f0fe2db447dc77341b6bbb03fc333843ba3ad54393cd678f
+size 30220

--- a/assets/Field1Thumbnail.png
+++ b/assets/Field1Thumbnail.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5893db6a8d7071e18453750ef9715e1591526fd7da54f8c4175fa699af10ab57
+size 11840

--- a/assets/OmegaStrikers1.jpg
+++ b/assets/OmegaStrikers1.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c0032af9a204f9b11be0f12cd9442a89f143c6247a74c863243246bcf403d109
+size 545485

--- a/assets/OmegaStrikers2.jpg
+++ b/assets/OmegaStrikers2.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2f707bac4ed6c9807e046c4843990889545a30962b29817bf6a1250be791004b
+size 467048

--- a/assets/OmegaStrikers3.jpg
+++ b/assets/OmegaStrikers3.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:664c2045dba2012bd04df3c4c6c8f34c66e31917011a0efc947b3c0d153897b1
+size 84476

--- a/assets/OmegaStrikers4.png
+++ b/assets/OmegaStrikers4.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:52770d29f06f854abd7448291b3911c55cacab56aafd1a32dda6ff7daa65e66f
+size 1741926

--- a/assets/OmegaStrikersThumbnail.png
+++ b/assets/OmegaStrikersThumbnail.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:952c7919f23b151b1b9b4a184863fd858f8aa3116178aad7f83ade1e40e75f23
+size 308667

--- a/assets/TTT_500.png
+++ b/assets/TTT_500.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f15817c361a1dd40096107ba8fe09d2f26884a3331559d3403b0757fac8e5b6f
+size 148373

--- a/assets/Th9yRTSuLd4_807.jpg
+++ b/assets/Th9yRTSuLd4_807.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f5c2714150c7754ba9c40dbaf0bc703b080b38d33f461e2948e254c0b02fe9c6
+size 133680

--- a/assets/TheAmazingEternals.jpg
+++ b/assets/TheAmazingEternals.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1ab0318bb06c3354dfa51c00a5b539ed9cf458d6a01d99126afc7398e65b072b
+size 21963

--- a/assets/WarframeThumbnail.jpg
+++ b/assets/WarframeThumbnail.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fba01ad2d3bf118b1836b6b1d718072aa9436862e1a0335b2c8847a4abf6788e
+size 13340

--- a/assets/Witchball1.png
+++ b/assets/Witchball1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6ad6e767c95847320e0488428e974bf1844f9286e1e6eb63ce9a3d5c60606689
+size 521323

--- a/assets/Witchball2.png
+++ b/assets/Witchball2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b619d9d7de2937dc5a03ff50a6e5139c00e93e6f8f9b0af61b853dc3fd5d219b
+size 515768

--- a/assets/Witchball4.png
+++ b/assets/Witchball4.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9e72a33e2e29a574590b7ed6c9644ffa26021eeb5134040c6a302db5f6a9eada
+size 506818

--- a/assets/Witchball5.png
+++ b/assets/Witchball5.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:858e8437fa8d30523b63e3f0661cee26f8f7a07039708c82a2ae6e15aec413f4
+size 510414

--- a/assets/Witchball6.png
+++ b/assets/Witchball6.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:38b91b2e32e79f0cf1b90d168507e1431f7abb4bb051cc034f54345253dc0b54
+size 303142

--- a/assets/WitchballThumbnail.png
+++ b/assets/WitchballThumbnail.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:23cca1600b738b3479381f098d0f9905e13e075149c006f47fc1a6d7ee51ac20
+size 30719

--- a/assets/ZZ_1000.jpg
+++ b/assets/ZZ_1000.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:740a4a94e67ef785961e1442f5871264a9320ae1b58543c52686159705b42959
+size 270385

--- a/assets/ZeroMarkThumbnail.png
+++ b/assets/ZeroMarkThumbnail.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7409b6dc427f43b4205a0ddf479e34192b00f802d55e9b98032838f9a57892e1
+size 33249

--- a/assets/maxresdefault-1_1000.jpg
+++ b/assets/maxresdefault-1_1000.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7adcbe58eb3b01813c5bbff4df5e30e6d58a40901fe06fcfed4b410c2b305650
+size 181395

--- a/assets/test_600.jpg
+++ b/assets/test_600.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:901c1e470c34b758452d7eecfd477ca218ecd592fc71b8babedee547c7ffc404
+size 98650

--- a/assets/the-amazing-eternals-1_590.jpg
+++ b/assets/the-amazing-eternals-1_590.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:81d45d0722d7809fd93ffaca8a39171ea539480373c9f2cffc7b45a04a2f2d11
+size 64421

--- a/assets/tumblr_n3udviTCwl1shf3nvo2_500.png
+++ b/assets/tumblr_n3udviTCwl1shf3nvo2_500.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:78080a7c522bd824b61c52eefef6337504d3aae7fac0a3b23971c1c48a1b8030
+size 120454

--- a/assets/tumblr_n3udviTCwl1shf3nvo3_500.png
+++ b/assets/tumblr_n3udviTCwl1shf3nvo3_500.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8cf1cbdaa61dad1e70add22752f5fc8e2ff491b28191ec3ee3c8b2a8a9c6ff94
+size 157154

--- a/assets/tumblr_n3udviTCwl1shf3nvo4_500.png
+++ b/assets/tumblr_n3udviTCwl1shf3nvo4_500.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7e16cc378c24180fb4c09123643547f33bbc2a4dad3c20aa01b5fe4edac061f4
+size 131367

--- a/assets/vanilla_deck_Page_2.png
+++ b/assets/vanilla_deck_Page_2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a2c703230606a350de5005f60b350a247c9a6be47463240f9680577bc257061e
+size 423627

--- a/assets/wetwork_resource_mat.png
+++ b/assets/wetwork_resource_mat.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:15f2403107c9e810e8e6f6d7cec4be654a4984489c5e71611bfa992146cef1e9
+size 29690

--- a/assets/wetwork_rules_02_Page_2.png
+++ b/assets/wetwork_rules_02_Page_2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:445dcf74f39c47c92e6f59f02887fa0ac81909b62fa7d71a1a246807e47ce86a
+size 221944

--- a/assets/wetwork_thumbnail.png
+++ b/assets/wetwork_thumbnail.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:40d10f84090a4632d5349635b882a5645fbf918be7ca9f52368cdf388787038e
+size 16324

--- a/brutal-arena.html
+++ b/brutal-arena.html
@@ -7,95 +7,73 @@
     <link rel="stylesheet" href="style.css" />
 </head>
 <body>
-    <header>
-        <nav class="top-nav">
-            <a href="index.html#projects" class="nav-item">PROJECTS</a>
-            <div class="nav-title">
-                SHERVIN GHAZAZANI – TECHNICAL GAME DESIGNER
+    <header class="site-header">
+        <div class="page">
+            <div class="nav-grid">
+                <div class="nav-left">
+                    <a href="index.html#projects"><b><span class="caption">Projects</span></b></a>
+                </div>
+                <div class="nav-center">
+                    <b><span class="caption">Shervin Ghazazani - Technical Game Designer</span></b>
+                </div>
+                <div class="nav-right">
+                    <a href="mailto:shervinghazazani@gmail.com"><b><span class="caption">Contact</span></b></a>
+                </div>
             </div>
-            <a href="index.html#contact" class="nav-item">CONTACT</a>
-        </nav>
+            <hr class="rule" />
+        </div>
     </header>
+
     <main class="project-page">
-        <section class="project-content">
-            <h1>Brutal Arena</h1>
-            <!-- Tagline and year -->
-            <p class="project-tagline">Turn‑Based Roguelike Tactics • 2013</p>
-            <div class="project-media"></div>
-            <p>Brutal Arena is a turn‑based tactics game where players assume control of a warrior to survive for as long as they can while fighting AI‑controlled enemies. The game features a unique theme that attempts to evoke the type of homemade games teenagers would have created in their bedrooms in the 1990s.</p>
-        </section>
-        <section class="project-screenshots">
-            <div class="screenshot-placeholder"></div>
-            <div class="screenshot-placeholder"></div>
-            <div class="screenshot-placeholder"></div>
-        </section>
-        <section class="project-grid-section">
-            <h2>Other Projects</h2>
-            <div class="project-grid">
-                <a href="omega-strikers.html" class="project">
-                    <div class="project-thumb" style="background-image: url('https://freight.cargo.site/w/100/i/V2548604313848078054190197947345/OmegaStrikersThumbnail.png'); background-size: cover; background-position: center;"></div>
-                    <div class="project-title">Omega Strikers</div>
-                </a>
-                <a href="chivalry-2.html" class="project">
-                    <div class="project-thumb" style="background-image: url('https://freight.cargo.site/w/100/i/J254858422750250841112505662417/Chivalry2Thumbnail.jpg'); background-size: cover; background-position: center;"></div>
-                    <div class="project-title">Chivalry 2</div>
-                </a>
-                <a href="warframe.html" class="project">
-                    <div class="project-thumb" style="background-image: url('https://freight.cargo.site/w/100/i/D2548583997102217360480205978577/WarframeThumbnail.jpg'); background-size: cover; background-position: center;"></div>
-                    <div class="project-title">Warframe</div>
-                </a>
-                <a href="amazing-eternals.html" class="project">
-                    <div class="project-thumb" style="background-image: url('https://freight.cargo.site/w/100/i/M2548583831192201161536498744273/TheAmazingEternals.jpg'); background-size: cover; background-position: center;"></div>
-                    <div class="project-title">Amazing Eternals</div>
-                </a>
-                <a href="field-1.html" class="project">
-                    <div class="project-thumb" style="background-image: url('https://freight.cargo.site/w/100/i/Z2548583629108119834048360790993/Field1Thumbnail.png'); background-size: cover; background-position: center;"></div>
-                    <div class="project-title">Field‑1</div>
-                </a>
-                <a href="zero-mark.html" class="project">
-                    <div class="project-thumb" style="background-image: url('https://freight.cargo.site/w/100/i/X254858340234224953936842775505/ZeroMarkThumbnail.png'); background-size: cover; background-position: center;"></div>
-                    <div class="project-title">Zero Mark</div>
-                </a>
-                <a href="witchball.html" class="project">
-                    <div class="project-thumb" style="background-image: url('https://freight.cargo.site/w/100/i/K2548580396334667660523149638609/wetwork_thumbnail.png'); background-size: cover; background-position: center;"></div>
-                    <div class="project-title">Witchball</div>
-                </a>
-                <a href="wetwork.html" class="project">
-                    <div class="project-thumb" style="background-image: url('https://freight.cargo.site/w/100/i/K2548580396334667660523149638609/wetwork_thumbnail.png'); background-size: cover; background-position: center;"></div>
-                    <div class="project-title">Wetwork</div>
-                </a>
-                <a href="index.html" class="project">
-                    <div class="project-thumb placeholder"></div>
-                    <div class="project-title">Back to Home</div>
-                </a>
-            </div>
-        </section>
+        <div class="page">
+            <section class="project-details">
+                <div class="project-meta">
+                    <b>Brutal Arena</b><br /><br />
+                    <span class="caption">Turn-Based Roguelike Tactics<br />2013</span>
+                </div>
+                <div class="project-body">
+                    <p>
+                        Brutal Arena is a turn-based tactics game where players assume control of a warrior to survive for as long as they can while fighting AI-controlled enemies. The game features a unique theme that attempts to evoke the type of homemade games teenagers would have created in their bedrooms in the 1990s.
+                    </p>
+                </div>
+            </section>
+            <section class="media-gallery">
+                <img src="assets/BrutalArenaStart.png" alt="Brutal Arena screenshot 1" />
+                <img src="assets/BrutalArenaGameplay2.png" alt="Brutal Arena screenshot 2" />
+                <img src="assets/BrutalArenaDeath.png" alt="Brutal Arena screenshot 3" />
+            </section>
+        </div>
     </main>
-    <footer class="footer">
-        <div class="footer-col">
-            <h3>Shervin Ghazazani</h3>
-            <ul class="contact-list">
-                <li><a href="mailto:shervinghazazani@gmail.com">Email</a></li>
-                <li><a href="#">LinkedIn</a></li>
-                <li><a href="#">Twitter</a></li>
-            </ul>
-        </div>
-        <div class="footer-col">
-            <h3>About Me</h3>
-            <p>
-                Hello and welcome to my portfolio! I'm a game designer at Odyssey
-                Interactive. My work tends to involve zero‑sum game systems,
-                fast‑paced dynamics, and visceral game feel.
-            </p>
-        </div>
-        <div class="footer-col">
-            <h3>Currently Consuming:</h3>
-            <ul>
-                <li>Witchfire (PC)</li>
-                <li>Dead Cells (iOS)</li>
-                <li>The Penguin (HBO)</li>
-                <li>3 Body Problem Trilogy (Audiobook)</li>
-            </ul>
+
+    <footer class="site-footer">
+        <div class="page">
+            <hr class="rule" />
+            <div class="footer-grid">
+                <div>
+                    <h3>Shervin Ghazazani</h3>
+                    <div class="caption footer-links">
+                        <a href="mailto:shervinghazazani@gmail.com">Email</a><br />
+                        <a href="https://www.linkedin.com/in/shervinghazazani/" target="_blank" rel="noreferrer">LinkedIn</a><br />
+                        <a href="https://www.twitter.com/gahzi" target="_blank" rel="noreferrer">Twitter</a>
+                    </div>
+                </div>
+                <div>
+                    <h3>About Me</h3>
+                    <div class="caption">
+                        Hello and welcome to my portfolio!<br /><br />
+                        I’m a game designer at Odyssey Interactive, specializing in competitive systems, fast-paced dynamics, and gameplay that feels immediately impactful.
+                    </div>
+                </div>
+                <div>
+                    <h3>Currently Consuming</h3>
+                    <div class="caption">
+                        - Witchfire (PC)<br />
+                        - Dead Cells (iOS)<br />
+                        - The Penguin (HBO)<br />
+                        - 3 Body Problem Trilogy (Audiobook)
+                    </div>
+                </div>
+            </div>
         </div>
     </footer>
 </body>

--- a/chivalry-2.html
+++ b/chivalry-2.html
@@ -7,110 +7,93 @@
     <link rel="stylesheet" href="style.css" />
 </head>
 <body>
-    <header>
-        <nav class="top-nav">
-            <a href="index.html#projects" class="nav-item">PROJECTS</a>
-            <div class="nav-title">
-                SHERVIN GHAZAZANI – TECHNICAL GAME DESIGNER
+    <header class="site-header">
+        <div class="page">
+            <div class="nav-grid">
+                <div class="nav-left">
+                    <a href="index.html#projects"><b><span class="caption">Projects</span></b></a>
+                </div>
+                <div class="nav-center">
+                    <b><span class="caption">Shervin Ghazazani - Technical Game Designer</span></b>
+                </div>
+                <div class="nav-right">
+                    <a href="mailto:shervinghazazani@gmail.com"><b><span class="caption">Contact</span></b></a>
+                </div>
             </div>
-            <a href="index.html#contact" class="nav-item">CONTACT</a>
-        </nav>
+            <hr class="rule" />
+        </div>
     </header>
+
     <main class="project-page">
-        <section class="project-content">
-            <h1>Chivalry 2</h1>
-            <!-- Tagline and year -->
-            <p class="project-tagline">MP Melee Slasher • 2021</p>
-            <div class="project-media"></div>
-            <p>The sequel to the 2012 classic, Chivalry 2 is a multiplayer first‑person melee fighting game that aims to bring accessibility to the “hard to learn, hard to master” slasher genre.</p>
-            <p>Coming onto the project mid‑development, I filled in missing features such as:</p>
-            <ul>
-                <li>Combat design support and implementation</li>
-                <li>Gamepad design and implementation (layout, auto‑assist, QoL features)</li>
-                <li>Progression design and implementation (global, class, and weapon XP curves)</li>
-                <li>Balance support and Redash query construction and maintenance</li>
-                <li>Customization item pricing and store maintenance</li>
-            </ul>
-            <p><strong>Notable Mentions:</strong></p>
-            <ul>
-                <li>Cross‑platform across PSN, PC, and Xbox</li>
-                <li>Received an 82 OpenCritic rating</li>
-                <li>Over 1 M sold in the first 2 months</li>
-            </ul>
-            <p><strong>Website:</strong> <a href="https://chivalry2.com/">https://chivalry2.com/</a></p>
-        </section>
-        <section class="project-screenshots">
-            <div class="screenshot-placeholder"></div>
-            <div class="screenshot-placeholder"></div>
-            <div class="screenshot-placeholder"></div>
-        </section>
-        <section class="project-grid-section">
-            <h2>Other Projects</h2>
-            <div class="project-grid">
-                <a href="omega-strikers.html" class="project">
-                    <div class="project-thumb" style="background-image: url('https://freight.cargo.site/w/100/i/V2548604313848078054190197947345/OmegaStrikersThumbnail.png'); background-size: cover; background-position: center;"></div>
-                    <div class="project-title">Omega Strikers</div>
-                </a>
-                <a href="warframe.html" class="project">
-                    <div class="project-thumb" style="background-image: url('https://freight.cargo.site/w/100/i/D2548583997102217360480205978577/WarframeThumbnail.jpg'); background-size: cover; background-position: center;"></div>
-                    <div class="project-title">Warframe</div>
-                </a>
-                <a href="amazing-eternals.html" class="project">
-                    <div class="project-thumb" style="background-image: url('https://freight.cargo.site/w/100/i/M2548583831192201161536498744273/TheAmazingEternals.jpg'); background-size: cover; background-position: center;"></div>
-                    <div class="project-title">Amazing Eternals</div>
-                </a>
-                <a href="field-1.html" class="project">
-                    <div class="project-thumb" style="background-image: url('https://freight.cargo.site/w/100/i/Z2548583629108119834048360790993/Field1Thumbnail.png'); background-size: cover; background-position: center;"></div>
-                    <div class="project-title">Field‑1</div>
-                </a>
-                <a href="zero-mark.html" class="project">
-                    <div class="project-thumb" style="background-image: url('https://freight.cargo.site/w/100/i/X254858340234224953936842775505/ZeroMarkThumbnail.png'); background-size: cover; background-position: center;"></div>
-                    <div class="project-title">Zero Mark</div>
-                </a>
-                <a href="witchball.html" class="project">
-                    <div class="project-thumb" style="background-image: url('https://freight.cargo.site/w/100/i/K2548580396334667660523149638609/wetwork_thumbnail.png'); background-size: cover; background-position: center;"></div>
-                    <div class="project-title">Witchball</div>
-                </a>
-                <a href="wetwork.html" class="project">
-                    <div class="project-thumb" style="background-image: url('https://freight.cargo.site/w/100/i/K2548580396334667660523149638609/wetwork_thumbnail.png'); background-size: cover; background-position: center;"></div>
-                    <div class="project-title">Wetwork</div>
-                </a>
-                <a href="brutal-arena.html" class="project">
-                    <div class="project-thumb" style="background-image: url('https://freight.cargo.site/w/100/i/A25485818171410110770633735060433/BrutalArenaThumbnail.png'); background-size: cover; background-position: center;"></div>
-                    <div class="project-title">Brutal Arena</div>
-                </a>
-                <a href="index.html" class="project">
-                    <div class="project-thumb placeholder"></div>
-                    <div class="project-title">Back to Home</div>
-                </a>
-            </div>
-        </section>
+        <div class="page">
+            <section class="project-details">
+                <div class="project-meta">
+                    <b>Chivalry 2</b><br /><br />
+                    <span class="caption">MP Melee Slasher<br />2021</span>
+                </div>
+                <div class="project-body">
+                    <p>
+                        The sequel to the 2012 classic, Chivalry 2 is a multiplayer first-person melee fighting game that aims to bring accessibility to the "hard to learn, hard to master" slasher genre.
+                    </p>
+                    <p>Coming onto the project mid-development, I filled in missing features such as:</p>
+                    <ul>
+                        <li>Combat design support and implementation</li>
+                        <li>Gamepad design and implementation (layout, auto-assist, QoL features)</li>
+                        <li>Progression design and implementation (Global, class, and weapon XP curves)</li>
+                        <li>Balance support and Redash query construction and maintenance</li>
+                        <li>Customization item pricing and store maintenance</li>
+                    </ul>
+                    <p>
+                        <b>Notable Mentions:</b><br />
+                        - Cross-platform across PSN, PC, and Xbox<br />
+                        - Received an 82 OpenCritic rating<br />
+                        - Over 1M sold in the first 2 months
+                    </p>
+                    <p>
+                        <b>Website:</b><br />
+                        <a href="https://chivalry2.com/" target="_blank" rel="noreferrer">https://chivalry2.com/</a>
+                    </p>
+                </div>
+            </section>
+            <section class="media-gallery">
+                <img src="assets/Chivalry-2-13_1000.jpg" alt="Chivalry 2 screenshot 1" />
+                <img src="assets/Chivalry-2-2021-06-05-23-49-42.mp4-VLC-media-player-6_6_2021-1_37_17-AM_1000.png" alt="Chivalry 2 screenshot 2" />
+                <img src="assets/Chivalry2_PAXE_3_1000.jpg" alt="Chivalry 2 screenshot 3" />
+                <img src="assets/9o7JLM-l2f4_1000.jpg" alt="Chivalry 2 screenshot 4" />
+                <img src="assets/083554_1000.jpg" alt="Chivalry 2 screenshot 5" />
+            </section>
+        </div>
     </main>
-    <footer class="footer">
-        <div class="footer-col">
-            <h3>Shervin Ghazazani</h3>
-            <ul class="contact-list">
-                <li><a href="mailto:shervinghazazani@gmail.com">Email</a></li>
-                <li><a href="#">LinkedIn</a></li>
-                <li><a href="#">Twitter</a></li>
-            </ul>
-        </div>
-        <div class="footer-col">
-            <h3>About Me</h3>
-            <p>
-                Hello and welcome to my portfolio! I'm a game designer at Odyssey
-                Interactive. My work tends to involve zero‑sum game systems,
-                fast‑paced dynamics, and visceral game feel.
-            </p>
-        </div>
-        <div class="footer-col">
-            <h3>Currently Consuming:</h3>
-            <ul>
-                <li>Witchfire (PC)</li>
-                <li>Dead Cells (iOS)</li>
-                <li>The Penguin (HBO)</li>
-                <li>3 Body Problem Trilogy (Audiobook)</li>
-            </ul>
+
+    <footer class="site-footer">
+        <div class="page">
+            <hr class="rule" />
+            <div class="footer-grid">
+                <div>
+                    <h3>Shervin Ghazazani</h3>
+                    <div class="caption footer-links">
+                        <a href="mailto:shervinghazazani@gmail.com">Email</a><br />
+                        <a href="https://www.linkedin.com/in/shervinghazazani/" target="_blank" rel="noreferrer">LinkedIn</a><br />
+                        <a href="https://www.twitter.com/gahzi" target="_blank" rel="noreferrer">Twitter</a>
+                    </div>
+                </div>
+                <div>
+                    <h3>About Me</h3>
+                    <div class="caption">
+                        Hello and welcome to my portfolio!<br /><br />
+                        I’m a game designer at Odyssey Interactive, specializing in competitive systems, fast-paced dynamics, and gameplay that feels immediately impactful.
+                    </div>
+                </div>
+                <div>
+                    <h3>Currently Consuming</h3>
+                    <div class="caption">
+                        - Witchfire (PC)<br />
+                        - Dead Cells (iOS)<br />
+                        - The Penguin (HBO)<br />
+                        - 3 Body Problem Trilogy (Audiobook)
+                    </div>
+                </div>
+            </div>
         </div>
     </footer>
 </body>

--- a/field-1.html
+++ b/field-1.html
@@ -7,103 +7,83 @@
     <link rel="stylesheet" href="style.css" />
 </head>
 <body>
-    <header>
-        <nav class="top-nav">
-            <a href="index.html#projects" class="nav-item">PROJECTS</a>
-            <div class="nav-title">
-                SHERVIN GHAZAZANI – TECHNICAL GAME DESIGNER
+    <header class="site-header">
+        <div class="page">
+            <div class="nav-grid">
+                <div class="nav-left">
+                    <a href="index.html#projects"><b><span class="caption">Projects</span></b></a>
+                </div>
+                <div class="nav-center">
+                    <b><span class="caption">Shervin Ghazazani - Technical Game Designer</span></b>
+                </div>
+                <div class="nav-right">
+                    <a href="mailto:shervinghazazani@gmail.com"><b><span class="caption">Contact</span></b></a>
+                </div>
             </div>
-            <a href="index.html#contact" class="nav-item">CONTACT</a>
-        </nav>
+            <hr class="rule" />
+        </div>
     </header>
+
     <main class="project-page">
-        <section class="project-content">
-            <h1>Field‑1</h1>
-            <!-- Tagline and year -->
-            <p class="project-tagline">Combat Air Hockey • 2014</p>
-            <div class="project-media"></div>
-            <p>Field‑1 feels like playing hockey inside a pinball machine. Part <em>Frogger</em>, part <em>Hokra</em>, part <em>American Gladiators</em>, Field‑1 is an arcade game that’s accessible and exciting for both players and spectators. The goal is to pilot your player into the opponent’s goal. Move faster by shedding weight, but a lighter player is vulnerable to chaotic collisions with heavier opponents and the physics obstacles that fill the field. The player with the most points at the end of the round is the winner.</p>
-            <p><strong>Notable Mentions:</strong></p>
-            <ul>
-                <li>Arcade edition complete with custom cabinet premiered at the PRACTICE 2013 game design conference</li>
-                <li>Included in the EVO Fighting Game Championship Indie Showcase</li>
-                <li>Won “Best Multiplayer” at RPI Gamefest 2014</li>
-                <li>Shown at the Smithsonian Indie Games Exhibition in 2018</li>
-                <li>Profiled by Indie Statik</li>
-            </ul>
-        </section>
-        <section class="project-screenshots">
-            <div class="screenshot-placeholder"></div>
-            <div class="screenshot-placeholder"></div>
-            <div class="screenshot-placeholder"></div>
-        </section>
-        <section class="project-grid-section">
-            <h2>Other Projects</h2>
-            <div class="project-grid">
-                <a href="omega-strikers.html" class="project">
-                    <div class="project-thumb" style="background-image: url('https://freight.cargo.site/w/100/i/V2548604313848078054190197947345/OmegaStrikersThumbnail.png'); background-size: cover; background-position: center;"></div>
-                    <div class="project-title">Omega Strikers</div>
-                </a>
-                <a href="chivalry-2.html" class="project">
-                    <div class="project-thumb" style="background-image: url('https://freight.cargo.site/w/100/i/J254858422750250841112505662417/Chivalry2Thumbnail.jpg'); background-size: cover; background-position: center;"></div>
-                    <div class="project-title">Chivalry 2</div>
-                </a>
-                <a href="warframe.html" class="project">
-                    <div class="project-thumb" style="background-image: url('https://freight.cargo.site/w/100/i/D2548583997102217360480205978577/WarframeThumbnail.jpg'); background-size: cover; background-position: center;"></div>
-                    <div class="project-title">Warframe</div>
-                </a>
-                <a href="amazing-eternals.html" class="project">
-                    <div class="project-thumb" style="background-image: url('https://freight.cargo.site/w/100/i/M2548583831192201161536498744273/TheAmazingEternals.jpg'); background-size: cover; background-position: center;"></div>
-                    <div class="project-title">Amazing Eternals</div>
-                </a>
-                <a href="zero-mark.html" class="project">
-                    <div class="project-thumb" style="background-image: url('https://freight.cargo.site/w/100/i/X254858340234224953936842775505/ZeroMarkThumbnail.png'); background-size: cover; background-position: center;"></div>
-                    <div class="project-title">Zero Mark</div>
-                </a>
-                <a href="witchball.html" class="project">
-                    <div class="project-thumb" style="background-image: url('https://freight.cargo.site/w/100/i/K2548580396334667660523149638609/wetwork_thumbnail.png'); background-size: cover; background-position: center;"></div>
-                    <div class="project-title">Witchball</div>
-                </a>
-                <a href="wetwork.html" class="project">
-                    <div class="project-thumb" style="background-image: url('https://freight.cargo.site/w/100/i/K2548580396334667660523149638609/wetwork_thumbnail.png'); background-size: cover; background-position: center;"></div>
-                    <div class="project-title">Wetwork</div>
-                </a>
-                <a href="brutal-arena.html" class="project">
-                    <div class="project-thumb" style="background-image: url('https://freight.cargo.site/w/100/i/A25485818171410110770633735060433/BrutalArenaThumbnail.png'); background-size: cover; background-position: center;"></div>
-                    <div class="project-title">Brutal Arena</div>
-                </a>
-                <a href="index.html" class="project">
-                    <div class="project-thumb placeholder"></div>
-                    <div class="project-title">Back to Home</div>
-                </a>
-            </div>
-        </section>
+        <div class="page">
+            <section class="project-details">
+                <div class="project-meta">
+                    <b>Field 1</b><br /><br />
+                    <span class="caption">Combat Air Hockey<br />2014</span>
+                </div>
+                <div class="project-body">
+                    <p>
+                        Field-1 feels like playing hockey inside a pinball machine. Part Frogger, part Hokra, part American Gladiators, Field-1 is an arcade game that's accessible and exciting for both players and spectators. The goal is to pilot your player into the opponent's goal. Move faster by shedding weight, but a lighter player is vulnerable to chaotic collisions with heavier opponents and the physics obstacles that fill the field. The player with the most points at the end of the round is the winner.
+                    </p>
+                    <p>
+                        <b>Notable Mentions:</b><br />
+                        - Arcade edition complete with custom cabinet premiered at the PRACTICE 2013 game design conference<br />
+                        - Included in the EVO Fighting Game Championship Indie Showcase<br />
+                        - Won "Best Multiplayer" at RPI Gamefest 2014<br />
+                        - Shown at the Smithsonian Indie Games Exhibition in 2018<br />
+                        - Profiled by Indie Statik
+                    </p>
+                </div>
+            </section>
+            <section class="media-gallery">
+                <img src="assets/Field-1AboutScreen.png" alt="Field-1 screenshot 1" />
+                <img src="assets/Field-1DrugScreen.png" alt="Field-1 screenshot 2" />
+                <img src="assets/Field-1Gameplay.png" alt="Field-1 screenshot 3" />
+                <img src="assets/Field-1TitleScreen.png" alt="Field-1 screenshot 4" />
+                <img src="assets/2013-05-16-20.33.46.jpg" alt="Field-1 screenshot 5" />
+            </section>
+        </div>
     </main>
-    <footer class="footer">
-        <div class="footer-col">
-            <h3>Shervin Ghazazani</h3>
-            <ul class="contact-list">
-                <li><a href="mailto:shervinghazazani@gmail.com">Email</a></li>
-                <li><a href="#">LinkedIn</a></li>
-                <li><a href="#">Twitter</a></li>
-            </ul>
-        </div>
-        <div class="footer-col">
-            <h3>About Me</h3>
-            <p>
-                Hello and welcome to my portfolio! I'm a game designer at Odyssey
-                Interactive. My work tends to involve zero‑sum game systems,
-                fast‑paced dynamics, and visceral game feel.
-            </p>
-        </div>
-        <div class="footer-col">
-            <h3>Currently Consuming:</h3>
-            <ul>
-                <li>Witchfire (PC)</li>
-                <li>Dead Cells (iOS)</li>
-                <li>The Penguin (HBO)</li>
-                <li>3 Body Problem Trilogy (Audiobook)</li>
-            </ul>
+
+    <footer class="site-footer">
+        <div class="page">
+            <hr class="rule" />
+            <div class="footer-grid">
+                <div>
+                    <h3>Shervin Ghazazani</h3>
+                    <div class="caption footer-links">
+                        <a href="mailto:shervinghazazani@gmail.com">Email</a><br />
+                        <a href="https://www.linkedin.com/in/shervinghazazani/" target="_blank" rel="noreferrer">LinkedIn</a><br />
+                        <a href="https://www.twitter.com/gahzi" target="_blank" rel="noreferrer">Twitter</a>
+                    </div>
+                </div>
+                <div>
+                    <h3>About Me</h3>
+                    <div class="caption">
+                        Hello and welcome to my portfolio!<br /><br />
+                        I’m a game designer at Odyssey Interactive, specializing in competitive systems, fast-paced dynamics, and gameplay that feels immediately impactful.
+                    </div>
+                </div>
+                <div>
+                    <h3>Currently Consuming</h3>
+                    <div class="caption">
+                        - Witchfire (PC)<br />
+                        - Dead Cells (iOS)<br />
+                        - The Penguin (HBO)<br />
+                        - 3 Body Problem Trilogy (Audiobook)
+                    </div>
+                </div>
+            </div>
         </div>
     </footer>
 </body>

--- a/index.html
+++ b/index.html
@@ -7,86 +7,95 @@
     <link rel="stylesheet" href="style.css" />
 </head>
 <body>
-    <!-- Top navigation bar -->
-    <header>
-        <nav class="top-nav">
-            <a href="#projects" class="nav-item">PROJECTS</a>
-            <div class="nav-title">
-                SHERVIN GHAZAZANI – TECHNICAL GAME DESIGNER
+    <header class="site-header">
+        <div class="page">
+            <div class="nav-grid">
+                <div class="nav-left">
+                    <a href="#projects"><b><span class="caption">Projects</span></b></a>
+                </div>
+                <div class="nav-center">
+                    <b><span class="caption">Shervin Ghazazani - Technical Game Designer</span></b>
+                </div>
+                <div class="nav-right">
+                    <a href="mailto:shervinghazazani@gmail.com"><b><span class="caption">Contact</span></b></a>
+                </div>
             </div>
-            <a href="#contact" class="nav-item">CONTACT</a>
-        </nav>
+            <hr class="rule" />
+        </div>
     </header>
 
-    <!-- Projects grid -->
     <main id="projects" class="projects-section">
-        <div class="project-grid">
-            <!-- Each project entry: placeholder image with title underneath -->
-            <a href="omega-strikers.html" class="project">
-                <div class="project-thumb" style="background-image: url('https://freight.cargo.site/w/100/i/V2548604313848078054190197947345/OmegaStrikersThumbnail.png'); background-size: cover; background-position: center;"></div>
-                <div class="project-title">Omega Strikers</div>
-            </a>
-            <a href="chivalry-2.html" class="project">
-                <div class="project-thumb" style="background-image: url('https://freight.cargo.site/w/100/i/J254858422750250841112505662417/Chivalry2Thumbnail.jpg'); background-size: cover; background-position: center;"></div>
-                <div class="project-title">Chivalry 2</div>
-            </a>
-            <a href="warframe.html" class="project">
-                <div class="project-thumb" style="background-image: url('https://freight.cargo.site/w/100/i/D2548583997102217360480205978577/WarframeThumbnail.jpg'); background-size: cover; background-position: center;"></div>
-                <div class="project-title">Warframe</div>
-            </a>
-            <a href="amazing-eternals.html" class="project">
-                <div class="project-thumb" style="background-image: url('https://freight.cargo.site/w/100/i/M2548583831192201161536498744273/TheAmazingEternals.jpg'); background-size: cover; background-position: center;"></div>
-                <div class="project-title">Amazing Eternals</div>
-            </a>
-            <a href="field-1.html" class="project">
-                <div class="project-thumb" style="background-image: url('https://freight.cargo.site/w/100/i/Z2548583629108119834048360790993/Field1Thumbnail.png'); background-size: cover; background-position: center;"></div>
-                <div class="project-title">Field‑1</div>
-            </a>
-            <a href="zero-mark.html" class="project">
-                <div class="project-thumb" style="background-image: url('https://freight.cargo.site/w/100/i/X254858340234224953936842775505/ZeroMarkThumbnail.png'); background-size: cover; background-position: center;"></div>
-                <div class="project-title">Zero Mark</div>
-            </a>
-            <a href="witchball.html" class="project">
-                <div class="project-thumb" style="background-image: url('https://freight.cargo.site/w/100/i/K2548580396334667660523149638609/wetwork_thumbnail.png'); background-size: cover; background-position: center;"></div>
-                <div class="project-title">Witchball</div>
-            </a>
-            <a href="wetwork.html" class="project">
-                <div class="project-thumb" style="background-image: url('https://freight.cargo.site/w/100/i/K2548580396334667660523149638609/wetwork_thumbnail.png'); background-size: cover; background-position: center;"></div>
-                <div class="project-title">Wetwork</div>
-            </a>
-            <a href="brutal-arena.html" class="project">
-                <div class="project-thumb" style="background-image: url('https://freight.cargo.site/w/100/i/A25485818171410110770633735060433/BrutalArenaThumbnail.png'); background-size: cover; background-position: center;"></div>
-                <div class="project-title">Brutal Arena</div>
-            </a>
+        <div class="page">
+            <div class="project-grid">
+                <a class="project-card" href="omega-strikers.html">
+                    <img src="assets/OmegaStrikersThumbnail.png" alt="Omega Strikers thumbnail" />
+                    <div class="caption">Omega Strikers</div>
+                </a>
+                <a class="project-card" href="chivalry-2.html">
+                    <img src="assets/Chivalry2Thumbnail.jpg" alt="Chivalry 2 thumbnail" />
+                    <div class="caption">Chivalry 2</div>
+                </a>
+                <a class="project-card" href="warframe.html">
+                    <img src="assets/WarframeThumbnail.jpg" alt="Warframe thumbnail" />
+                    <div class="caption">Warframe</div>
+                </a>
+                <a class="project-card" href="amazing-eternals.html">
+                    <img src="assets/TheAmazingEternals.jpg" alt="Amazing Eternals thumbnail" />
+                    <div class="caption">Amazing Eternals</div>
+                </a>
+                <a class="project-card" href="field-1.html">
+                    <img src="assets/Field1Thumbnail.png" alt="Field 1 thumbnail" />
+                    <div class="caption">Field-1</div>
+                </a>
+                <a class="project-card" href="zero-mark.html">
+                    <img src="assets/ZeroMarkThumbnail.png" alt="Zero Mark thumbnail" />
+                    <div class="caption">Zero Mark</div>
+                </a>
+                <a class="project-card" href="witchball.html">
+                    <img src="assets/WitchballThumbnail.png" alt="Witchball thumbnail" />
+                    <div class="caption">Witchball</div>
+                </a>
+                <a class="project-card" href="wetwork.html">
+                    <img src="assets/wetwork_thumbnail.png" alt="Wetwork thumbnail" />
+                    <div class="caption">Wetwork</div>
+                </a>
+                <a class="project-card" href="brutal-arena.html">
+                    <img src="assets/BrutalArenaThumbnail.png" alt="Brutal Arena thumbnail" />
+                    <div class="caption">Brutal Arena</div>
+                </a>
+            </div>
         </div>
     </main>
 
-    <!-- Footer with three columns: contact, about, and current interests -->
-    <footer id="contact" class="footer">
-        <div class="footer-col">
-            <h3>Shervin Ghazazani</h3>
-            <ul class="contact-list">
-                <li><a href="mailto:shervinghazazani@gmail.com">Email</a></li>
-                <li><a href="#">LinkedIn</a></li>
-                <li><a href="#">Twitter</a></li>
-            </ul>
-        </div>
-        <div class="footer-col">
-            <h3>About Me</h3>
-            <p>
-                Hello and welcome to my portfolio! I'm a game designer at Odyssey
-                Interactive. My work tends to involve zero‑sum game systems,
-                fast‑paced dynamics, and visceral game feel.
-            </p>
-        </div>
-        <div class="footer-col">
-            <h3>Currently Consuming:</h3>
-            <ul>
-                <li>Witchfire (PC)</li>
-                <li>Dead Cells (iOS)</li>
-                <li>The Penguin (HBO)</li>
-                <li>3 Body Problem Trilogy (Audiobook)</li>
-            </ul>
+    <footer class="site-footer">
+        <div class="page">
+            <hr class="rule" />
+            <div class="footer-grid">
+                <div>
+                    <h3>Shervin Ghazazani</h3>
+                    <div class="caption footer-links">
+                        <a href="mailto:shervinghazazani@gmail.com">Email</a><br />
+                        <a href="https://www.linkedin.com/in/shervinghazazani/" target="_blank" rel="noreferrer">LinkedIn</a><br />
+                        <a href="https://www.twitter.com/gahzi" target="_blank" rel="noreferrer">Twitter</a>
+                    </div>
+                </div>
+                <div>
+                    <h3>About Me</h3>
+                    <div class="caption">
+                        Hello and welcome to my portfolio!<br /><br />
+                        I’m a game designer at Odyssey Interactive, specializing in competitive systems, fast-paced dynamics, and gameplay that feels immediately impactful.
+                    </div>
+                </div>
+                <div>
+                    <h3>Currently Consuming</h3>
+                    <div class="caption">
+                        - Witchfire (PC)<br />
+                        - Dead Cells (iOS)<br />
+                        - The Penguin (HBO)<br />
+                        - 3 Body Problem Trilogy (Audiobook)
+                    </div>
+                </div>
+            </div>
         </div>
     </footer>
 </body>

--- a/omega-strikers.html
+++ b/omega-strikers.html
@@ -7,101 +7,90 @@
     <link rel="stylesheet" href="style.css" />
 </head>
 <body>
-    <!-- Top navigation bar -->
-    <header>
-        <nav class="top-nav">
-            <a href="index.html#projects" class="nav-item">PROJECTS</a>
-            <div class="nav-title">
-                SHERVIN GHAZAZANI – TECHNICAL GAME DESIGNER
+    <header class="site-header">
+        <div class="page">
+            <div class="nav-grid">
+                <div class="nav-left">
+                    <a href="index.html#projects"><b><span class="caption">Projects</span></b></a>
+                </div>
+                <div class="nav-center">
+                    <b><span class="caption">Shervin Ghazazani - Technical Game Designer</span></b>
+                </div>
+                <div class="nav-right">
+                    <a href="mailto:shervinghazazani@gmail.com"><b><span class="caption">Contact</span></b></a>
+                </div>
             </div>
-            <a href="index.html#contact" class="nav-item">CONTACT</a>
-        </nav>
+            <hr class="rule" />
+        </div>
     </header>
 
     <main class="project-page">
-        <section class="project-content">
-            <h1>Omega Strikers</h1>
-            <!-- Tagline and year -->
-            <p class="project-tagline">Footbrawler • 2023</p>
-            <div class="project-media"></div>
-            <p>Vivamus vulputate elit ac mauris fermentum, at interdum risus vehicula. Maecenas id viverra purus. Aenean tempus ligula in convallis porttitor. Morbi finibus lobortis elit sit amet fermentum. Cras rhoncus lorem accumsan nisl aliquam, vel elementum urna mollis.</p>
-            <p>Aenean congue a velit vitae porta ornare. Praesent consequat et dolor in venenatis. Quisque vitae diam nisl. Aliquam eget nibh non leo. Duis condimentum nisi hendrerit, hendrerit eros sed, dapibus lorem. In in orci eleifend, dictum justo sed, efficitur turpis. Curabitur ut varius velit.</p>
-        </section>
-        <section class="project-screenshots">
-            <div class="screenshot-placeholder"></div>
-            <div class="screenshot-placeholder"></div>
-            <div class="screenshot-placeholder"></div>
-        </section>
-        <section class="project-grid-section">
-            <h2>Other Projects</h2>
-            <div class="project-grid">
-                <!-- Repeat project links for navigation -->
-                <a href="chivalry-2.html" class="project">
-                    <div class="project-thumb" style="background-image: url('https://freight.cargo.site/w/100/i/J254858422750250841112505662417/Chivalry2Thumbnail.jpg'); background-size: cover; background-position: center;"></div>
-                    <div class="project-title">Chivalry 2</div>
-                </a>
-                <a href="warframe.html" class="project">
-                    <div class="project-thumb" style="background-image: url('https://freight.cargo.site/w/100/i/D2548583997102217360480205978577/WarframeThumbnail.jpg'); background-size: cover; background-position: center;"></div>
-                    <div class="project-title">Warframe</div>
-                </a>
-                <a href="amazing-eternals.html" class="project">
-                    <div class="project-thumb" style="background-image: url('https://freight.cargo.site/w/100/i/M2548583831192201161536498744273/TheAmazingEternals.jpg'); background-size: cover; background-position: center;"></div>
-                    <div class="project-title">Amazing Eternals</div>
-                </a>
-                <a href="field-1.html" class="project">
-                    <div class="project-thumb" style="background-image: url('https://freight.cargo.site/w/100/i/Z2548583629108119834048360790993/Field1Thumbnail.png'); background-size: cover; background-position: center;"></div>
-                    <div class="project-title">Field‑1</div>
-                </a>
-                <a href="zero-mark.html" class="project">
-                    <div class="project-thumb" style="background-image: url('https://freight.cargo.site/w/100/i/X254858340234224953936842775505/ZeroMarkThumbnail.png'); background-size: cover; background-position: center;"></div>
-                    <div class="project-title">Zero Mark</div>
-                </a>
-                <a href="witchball.html" class="project">
-                    <div class="project-thumb" style="background-image: url('https://freight.cargo.site/w/100/i/K2548580396334667660523149638609/wetwork_thumbnail.png'); background-size: cover; background-position: center;"></div>
-                    <div class="project-title">Witchball</div>
-                </a>
-                <a href="wetwork.html" class="project">
-                    <div class="project-thumb" style="background-image: url('https://freight.cargo.site/w/100/i/K2548580396334667660523149638609/wetwork_thumbnail.png'); background-size: cover; background-position: center;"></div>
-                    <div class="project-title">Wetwork</div>
-                </a>
-                <a href="brutal-arena.html" class="project">
-                    <div class="project-thumb" style="background-image: url('https://freight.cargo.site/w/100/i/A25485818171410110770633735060433/BrutalArenaThumbnail.png'); background-size: cover; background-position: center;"></div>
-                    <div class="project-title">Brutal Arena</div>
-                </a>
-                <a href="index.html" class="project">
-                    <div class="project-thumb placeholder"></div>
-                    <div class="project-title">Back to Home</div>
-                </a>
-            </div>
-        </section>
+        <div class="page">
+            <section class="project-details">
+                <div class="project-meta">
+                    <b>Omega Strikers</b><br /><br />
+                    <span class="caption">Footbrawler<br />2023</span>
+                </div>
+                <div class="project-body">
+                    <p>
+                        The first title for a new studio, Omega Strikers is a multiplayer top-down footbrawler that blends sports games like Windjammers with MOBAs like League of Legends.
+                    </p>
+                    <p>As the sole technical designer at the studio, I worked on a lot of features, including:</p>
+                    <ul>
+                        <li>Character design support and implementation</li>
+                        <li>Game mode design and implementation</li>
+                        <li>Gamepad and touch control design and implementation (layout, auto-assist, QoL features)</li>
+                        <li>Tutorial and Practice mode design and implementation</li>
+                    </ul>
+                    <p>
+                        <b>Notable Mentions:</b><br />
+                        - Nominated for Online Game of the Year at the DICE Awards 2023
+                    </p>
+                    <p>
+                        <b>Website:</b><br />
+                        <a href="https://store.steampowered.com/app/1869590/Omega_Strikers/" target="_blank" rel="noreferrer">https://store.steampowered.com/app/1869590/Omega_Strikers/</a>
+                    </p>
+                </div>
+            </section>
+            <section class="media-gallery">
+                <img src="assets/OmegaStrikers1.jpg" alt="Omega Strikers screenshot 1" />
+                <img src="assets/OmegaStrikers2.jpg" alt="Omega Strikers screenshot 2" />
+                <img src="assets/OmegaStrikers3.jpg" alt="Omega Strikers screenshot 3" />
+                <img src="assets/OmegaStrikers4.png" alt="Omega Strikers screenshot 4" />
+                <img src="assets/AimAssist4_1000.png" alt="Omega Strikers aim assist" />
+            </section>
+        </div>
     </main>
 
-    <!-- Footer reused from index -->
-    <footer class="footer">
-        <div class="footer-col">
-            <h3>Shervin Ghazazani</h3>
-            <ul class="contact-list">
-                <li><a href="mailto:shervinghazazani@gmail.com">Email</a></li>
-                <li><a href="#">LinkedIn</a></li>
-                <li><a href="#">Twitter</a></li>
-            </ul>
-        </div>
-        <div class="footer-col">
-            <h3>About Me</h3>
-            <p>
-                Hello and welcome to my portfolio! I'm a game designer at Odyssey
-                Interactive. My work tends to involve zero‑sum game systems,
-                fast‑paced dynamics, and visceral game feel.
-            </p>
-        </div>
-        <div class="footer-col">
-            <h3>Currently Consuming:</h3>
-            <ul>
-                <li>Witchfire (PC)</li>
-                <li>Dead Cells (iOS)</li>
-                <li>The Penguin (HBO)</li>
-                <li>3 Body Problem Trilogy (Audiobook)</li>
-            </ul>
+    <footer class="site-footer">
+        <div class="page">
+            <hr class="rule" />
+            <div class="footer-grid">
+                <div>
+                    <h3>Shervin Ghazazani</h3>
+                    <div class="caption footer-links">
+                        <a href="mailto:shervinghazazani@gmail.com">Email</a><br />
+                        <a href="https://www.linkedin.com/in/shervinghazazani/" target="_blank" rel="noreferrer">LinkedIn</a><br />
+                        <a href="https://www.twitter.com/gahzi" target="_blank" rel="noreferrer">Twitter</a>
+                    </div>
+                </div>
+                <div>
+                    <h3>About Me</h3>
+                    <div class="caption">
+                        Hello and welcome to my portfolio!<br /><br />
+                        I’m a game designer at Odyssey Interactive, specializing in competitive systems, fast-paced dynamics, and gameplay that feels immediately impactful.
+                    </div>
+                </div>
+                <div>
+                    <h3>Currently Consuming</h3>
+                    <div class="caption">
+                        - Witchfire (PC)<br />
+                        - Dead Cells (iOS)<br />
+                        - The Penguin (HBO)<br />
+                        - 3 Body Problem Trilogy (Audiobook)
+                    </div>
+                </div>
+            </div>
         </div>
     </footer>
 </body>

--- a/style.css
+++ b/style.css
@@ -1,15 +1,22 @@
-/* Base typography and reset */
+:root {
+    --page-padding: 3.5rem;
+    --grid-gap: 1rem;
+    --text-color: #1a1a1a;
+    --rule-color: #d0d0d0;
+    --caption-color: #4a4a4a;
+}
+
 * {
+    box-sizing: border-box;
     margin: 0;
     padding: 0;
-    box-sizing: border-box;
 }
 
 body {
     font-family: "Times New Roman", Times, serif;
-    color: #444;
-    background-color: #fff;
-    line-height: 1.5;
+    color: var(--text-color);
+    background: #fff;
+    line-height: 1.6;
 }
 
 a {
@@ -17,167 +24,200 @@ a {
     text-decoration: none;
 }
 
-/* Top navigation bar */
-.top-nav {
-    display: flex;
-    justify-content: space-between;
+img {
+    display: block;
+    width: 100%;
+    height: auto;
+}
+
+.page {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 0 var(--page-padding);
+}
+
+.caption {
+    font-size: 0.9rem;
+    color: var(--caption-color);
+}
+
+.rule {
+    border: none;
+    border-top: 1px solid var(--rule-color);
+    margin: 1.5rem 0;
+}
+
+.site-header {
+    padding-top: 2rem;
+}
+
+.site-header .nav-grid {
+    display: grid;
+    grid-template-columns: repeat(12, 1fr);
     align-items: center;
-    padding: 2rem 4rem;
-    border-bottom: 1px solid #ccc;
-    font-size: 0.8rem;
+    gap: 2rem;
+}
+
+.nav-left {
+    grid-column: span 3;
+}
+
+.nav-center {
+    grid-column: span 6;
+    text-align: center;
+}
+
+.nav-right {
+    grid-column: span 3;
+    text-align: right;
+}
+
+.nav-left .caption,
+.nav-center .caption,
+.nav-right .caption {
     text-transform: uppercase;
-    letter-spacing: 1px;
+    letter-spacing: 0.08em;
+    font-size: 0.8rem;
 }
 
-.top-nav .nav-title {
-    font-weight: 400;
-    text-align: center;
-    flex: 1;
-}
-
-.top-nav .nav-item {
-    flex-basis: 6rem;
-    text-align: center;
-}
-
-/* Projects grid */
 .projects-section {
-    padding: 4rem 4rem;
+    padding: 2rem 0 4rem;
 }
 
 .project-grid {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: center;
+    display: grid;
+    grid-template-columns: repeat(9, minmax(0, 1fr));
+    gap: var(--grid-gap);
+    align-items: start;
+    justify-items: center;
+}
+
+.project-card {
+    width: 100%;
+    text-align: center;
+}
+
+.project-card img {
+    border: 1px solid #ddd;
+}
+
+.project-card .caption {
+    margin-top: 0.6rem;
+    font-size: 0.85rem;
+    text-transform: none;
+    letter-spacing: 0.02em;
+}
+
+.project-page {
+    padding: 2.5rem 0 4rem;
+}
+
+.project-details {
+    display: grid;
+    grid-template-columns: repeat(12, 1fr);
+    gap: 2rem;
+}
+
+.project-details .project-meta {
+    grid-column: span 4;
+}
+
+.project-details .project-body {
+    grid-column: span 8;
+}
+
+.project-details .project-meta b {
+    font-size: 1.1rem;
+}
+
+.project-details p,
+.project-details ul {
+    margin-bottom: 1rem;
+}
+
+.project-details ul {
+    padding-left: 1.2rem;
+}
+
+.media-gallery {
+    margin-top: 2.5rem;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
     gap: 1rem;
 }
 
-.project {
-    text-align: center;
-    width: 120px;
-    /* Ensure that project items are block elements so anchor tags with this class behave like blocks */
-    display: block;
-}
-
-.project-thumb {
-    width: 100%;
-    height: 70px;
-    background-color: #eee;
+.media-gallery img {
     border: 1px solid #ddd;
-    margin-bottom: 0.5rem;
 }
 
-.project-title {
-    font-size: 0.8rem;
-    letter-spacing: 0.5px;
+.site-footer {
+    padding: 2rem 0 4rem;
 }
 
-/* Footer section */
-.footer {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: space-between;
-    gap: 2rem;
-    border-top: 1px solid #ccc;
-    padding: 4rem 4rem;
-    font-size: 0.85rem;
+.footer-grid {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 3rem;
 }
 
-.footer-col {
-    flex: 1;
-    min-width: 200px;
-}
-
-.footer-col h3 {
-    margin-bottom: 0.5rem;
-    font-size: 1rem;
+.footer-grid h3 {
+    font-style: italic;
     font-weight: 600;
+    margin-bottom: 0.5rem;
 }
 
-.footer-col ul {
-    list-style: none;
-    padding-left: 0;
+.footer-grid .caption {
+    font-size: 0.9rem;
+    color: var(--caption-color);
 }
 
-.footer-col ul li {
+.footer-links a {
+    display: inline-block;
     margin-bottom: 0.3rem;
 }
 
-.contact-list li a {
-    color: #0066cc;
-    text-decoration: underline;
+@media (max-width: 900px) {
+    :root {
+        --page-padding: 2rem;
+    }
+
+    .project-grid {
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+
+    .project-details {
+        grid-template-columns: 1fr;
+    }
+
+    .project-details .project-meta,
+    .project-details .project-body {
+        grid-column: auto;
+    }
+
+    .footer-grid {
+        grid-template-columns: 1fr;
+    }
 }
 
 @media (max-width: 600px) {
-    .top-nav {
-        flex-direction: column;
-        align-items: flex-start;
-        gap: 0.5rem;
+    :root {
+        --page-padding: 1.5rem;
     }
-    .top-nav .nav-title {
+
+    .nav-grid {
+        grid-template-columns: 1fr;
         text-align: left;
-        flex: none;
     }
-    .projects-section {
-        padding: 1rem;
+
+    .nav-left,
+    .nav-center,
+    .nav-right {
+        grid-column: auto;
+        text-align: left;
     }
-    .project {
-        width: 45%;
+
+    .project-grid {
+        grid-template-columns: 1fr;
+        gap: 3rem;
     }
-}
-
-/* Project page specific styles */
-.project-page {
-    padding: 2rem;
-}
-
-.project-content h1 {
-    font-size: 1.5rem;
-    margin-bottom: 1rem;
-}
-
-/* Large media placeholder on project pages */
-.project-media {
-    width: 100%;
-    height: 300px;
-    background-color: #eee;
-    border: 1px solid #ddd;
-    margin-bottom: 1rem;
-}
-
-.project-content p {
-    margin-bottom: 1rem;
-}
-
-.project-grid-section {
-    margin-top: 3rem;
-}
-
-.project-grid-section h2 {
-    font-size: 1.2rem;
-    margin-bottom: 1rem;
-}
-
-/* Tagline and meta info on project pages */
-.project-tagline {
-    font-size: 0.9rem;
-    color: #666;
-    margin-bottom: 1rem;
-    font-style: italic;
-}
-
-/* Screenshot gallery on project pages */
-.project-screenshots {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 1rem;
-    justify-content: center;
-    margin-top: 2rem;
-}
-
-.screenshot-placeholder {
-    flex: 1 1 300px;
-    height: 200px;
-    background-color: #eee;
-    border: 1px solid #ddd;
 }

--- a/warframe.html
+++ b/warframe.html
@@ -7,97 +7,85 @@
     <link rel="stylesheet" href="style.css" />
 </head>
 <body>
-    <header>
-        <nav class="top-nav">
-            <a href="index.html#projects" class="nav-item">PROJECTS</a>
-            <div class="nav-title">
-                SHERVIN GHAZAZANI – TECHNICAL GAME DESIGNER
+    <header class="site-header">
+        <div class="page">
+            <div class="nav-grid">
+                <div class="nav-left">
+                    <a href="index.html#projects"><b><span class="caption">Projects</span></b></a>
+                </div>
+                <div class="nav-center">
+                    <b><span class="caption">Shervin Ghazazani - Technical Game Designer</span></b>
+                </div>
+                <div class="nav-right">
+                    <a href="mailto:shervinghazazani@gmail.com"><b><span class="caption">Contact</span></b></a>
+                </div>
             </div>
-            <a href="index.html#contact" class="nav-item">CONTACT</a>
-        </nav>
+            <hr class="rule" />
+        </div>
     </header>
+
     <main class="project-page">
-        <section class="project-content">
-            <h1>Warframe</h1>
-            <!-- Tagline and year -->
-            <p class="project-tagline">Looter Shooter • 2018</p>
-            <div class="project-media"></div>
-            <p>Warframe is a free‑to‑play third‑person action RPG set in a continually evolving sci‑fi world. As a technical designer on the project I contributed to the <em>Fortuna</em> open‑world expansion, developing and refining the bounty and quest systems and helping implement new reward structures.</p>
-            <p>I also assisted with the <em>Railjack</em> expansion, designing and balancing ship combat, progression, and resource systems. These updates, some of the largest and best‑received in Warframe’s history, introduced varied gameplay and extended the game’s longevity.</p>
-            <p><strong>Website:</strong> <a href="https://www.warframe.com/">https://www.warframe.com/</a></p>
-        </section>
-        <section class="project-screenshots">
-            <div class="screenshot-placeholder"></div>
-            <div class="screenshot-placeholder"></div>
-            <div class="screenshot-placeholder"></div>
-        </section>
-        <section class="project-grid-section">
-            <h2>Other Projects</h2>
-            <div class="project-grid">
-                <a href="omega-strikers.html" class="project">
-                    <div class="project-thumb" style="background-image: url('https://freight.cargo.site/w/100/i/V2548604313848078054190197947345/OmegaStrikersThumbnail.png'); background-size: cover; background-position: center;"></div>
-                    <div class="project-title">Omega Strikers</div>
-                </a>
-                <a href="chivalry-2.html" class="project">
-                    <div class="project-thumb" style="background-image: url('https://freight.cargo.site/w/100/i/J254858422750250841112505662417/Chivalry2Thumbnail.jpg'); background-size: cover; background-position: center;"></div>
-                    <div class="project-title">Chivalry 2</div>
-                </a>
-                <a href="amazing-eternals.html" class="project">
-                    <div class="project-thumb" style="background-image: url('https://freight.cargo.site/w/100/i/M2548583831192201161536498744273/TheAmazingEternals.jpg'); background-size: cover; background-position: center;"></div>
-                    <div class="project-title">Amazing Eternals</div>
-                </a>
-                <a href="field-1.html" class="project">
-                    <div class="project-thumb" style="background-image: url('https://freight.cargo.site/w/100/i/Z2548583629108119834048360790993/Field1Thumbnail.png'); background-size: cover; background-position: center;"></div>
-                    <div class="project-title">Field‑1</div>
-                </a>
-                <a href="zero-mark.html" class="project">
-                    <div class="project-thumb" style="background-image: url('https://freight.cargo.site/w/100/i/X254858340234224953936842775505/ZeroMarkThumbnail.png'); background-size: cover; background-position: center;"></div>
-                    <div class="project-title">Zero Mark</div>
-                </a>
-                <a href="witchball.html" class="project">
-                    <div class="project-thumb" style="background-image: url('https://freight.cargo.site/w/100/i/K2548580396334667660523149638609/wetwork_thumbnail.png'); background-size: cover; background-position: center;"></div>
-                    <div class="project-title">Witchball</div>
-                </a>
-                <a href="wetwork.html" class="project">
-                    <div class="project-thumb" style="background-image: url('https://freight.cargo.site/w/100/i/K2548580396334667660523149638609/wetwork_thumbnail.png'); background-size: cover; background-position: center;"></div>
-                    <div class="project-title">Wetwork</div>
-                </a>
-                <a href="brutal-arena.html" class="project">
-                    <div class="project-thumb" style="background-image: url('https://freight.cargo.site/w/100/i/A25485818171410110770633735060433/BrutalArenaThumbnail.png'); background-size: cover; background-position: center;"></div>
-                    <div class="project-title">Brutal Arena</div>
-                </a>
-                <a href="index.html" class="project">
-                    <div class="project-thumb placeholder"></div>
-                    <div class="project-title">Back to Home</div>
-                </a>
-            </div>
-        </section>
+        <div class="page">
+            <section class="project-details">
+                <div class="project-meta">
+                    <b>Warframe</b><br /><br />
+                    <span class="caption">Looter Shooter<br />2018</span>
+                </div>
+                <div class="project-body">
+                    <p>
+                        One of the early free-to-play games to arrive on consoles, Warframe is a third-person action RPG where players sweep through procedurally generated levels using a variety of weapons and abilities to complete missions and grow stronger.
+                    </p>
+                    <p>
+                        I mainly worked on Fortuna, the game's second open-world map. Fortuna introduced improvements to the bounty and quest system, as well as new systems such as animal conservation. The update also introduced Railjack, the space battle game mode that was one of the most ambitious features ever.
+                    </p>
+                    <p>
+                        <b>Notable Mentions:</b><br />
+                        One of the biggest and best-received updates in the game's history.
+                    </p>
+                    <p>
+                        <b>Website</b><br />
+                        <a href="https://www.warframe.com/" target="_blank" rel="noreferrer">https://www.warframe.com/</a>
+                    </p>
+                </div>
+            </section>
+            <section class="media-gallery">
+                <img src="assets/maxresdefault-1_1000.jpg" alt="Warframe screenshot 1" />
+                <img src="assets/ZZ_1000.jpg" alt="Warframe screenshot 2" />
+                <img src="assets/Th9yRTSuLd4_807.jpg" alt="Warframe screenshot 3" />
+                <img src="assets/Exploiter-Orb-Fight-Guide-7_700.jpg" alt="Warframe screenshot 4" />
+            </section>
+        </div>
     </main>
-    <footer class="footer">
-        <div class="footer-col">
-            <h3>Shervin Ghazazani</h3>
-            <ul class="contact-list">
-                <li><a href="mailto:shervinghazazani@gmail.com">Email</a></li>
-                <li><a href="#">LinkedIn</a></li>
-                <li><a href="#">Twitter</a></li>
-            </ul>
-        </div>
-        <div class="footer-col">
-            <h3>About Me</h3>
-            <p>
-                Hello and welcome to my portfolio! I'm a game designer at Odyssey
-                Interactive. My work tends to involve zero‑sum game systems,
-                fast‑paced dynamics, and visceral game feel.
-            </p>
-        </div>
-        <div class="footer-col">
-            <h3>Currently Consuming:</h3>
-            <ul>
-                <li>Witchfire (PC)</li>
-                <li>Dead Cells (iOS)</li>
-                <li>The Penguin (HBO)</li>
-                <li>3 Body Problem Trilogy (Audiobook)</li>
-            </ul>
+
+    <footer class="site-footer">
+        <div class="page">
+            <hr class="rule" />
+            <div class="footer-grid">
+                <div>
+                    <h3>Shervin Ghazazani</h3>
+                    <div class="caption footer-links">
+                        <a href="mailto:shervinghazazani@gmail.com">Email</a><br />
+                        <a href="https://www.linkedin.com/in/shervinghazazani/" target="_blank" rel="noreferrer">LinkedIn</a><br />
+                        <a href="https://www.twitter.com/gahzi" target="_blank" rel="noreferrer">Twitter</a>
+                    </div>
+                </div>
+                <div>
+                    <h3>About Me</h3>
+                    <div class="caption">
+                        Hello and welcome to my portfolio!<br /><br />
+                        I’m a game designer at Odyssey Interactive, specializing in competitive systems, fast-paced dynamics, and gameplay that feels immediately impactful.
+                    </div>
+                </div>
+                <div>
+                    <h3>Currently Consuming</h3>
+                    <div class="caption">
+                        - Witchfire (PC)<br />
+                        - Dead Cells (iOS)<br />
+                        - The Penguin (HBO)<br />
+                        - 3 Body Problem Trilogy (Audiobook)
+                    </div>
+                </div>
+            </div>
         </div>
     </footer>
 </body>

--- a/wetwork.html
+++ b/wetwork.html
@@ -7,100 +7,78 @@
     <link rel="stylesheet" href="style.css" />
 </head>
 <body>
-    <header>
-        <nav class="top-nav">
-            <a href="index.html#projects" class="nav-item">PROJECTS</a>
-            <div class="nav-title">
-                SHERVIN GHAZAZANI – TECHNICAL GAME DESIGNER
+    <header class="site-header">
+        <div class="page">
+            <div class="nav-grid">
+                <div class="nav-left">
+                    <a href="index.html#projects"><b><span class="caption">Projects</span></b></a>
+                </div>
+                <div class="nav-center">
+                    <b><span class="caption">Shervin Ghazazani - Technical Game Designer</span></b>
+                </div>
+                <div class="nav-right">
+                    <a href="mailto:shervinghazazani@gmail.com"><b><span class="caption">Contact</span></b></a>
+                </div>
             </div>
-            <a href="index.html#contact" class="nav-item">CONTACT</a>
-        </nav>
+            <hr class="rule" />
+        </div>
     </header>
+
     <main class="project-page">
-        <section class="project-content">
-            <h1>Wetwork</h1>
-            <!-- Tagline and year -->
-            <p class="project-tagline">Pong‑like • 2013</p>
-            <div class="project-media"></div>
-            <p>A one‑button pong‑like game where two players battle in an ever‑changing ruleset.</p>
-            <p><strong>Notable Mentions:</strong></p>
-            <ul>
-                <li>Included in the NYU Game Center’s annual NO QUARTER exhibition</li>
-                <li>Featured in NY World Science Festival in 2013</li>
-            </ul>
-        </section>
-        <section class="project-screenshots">
-            <div class="screenshot-placeholder"></div>
-            <div class="screenshot-placeholder"></div>
-            <div class="screenshot-placeholder"></div>
-        </section>
-        <section class="project-grid-section">
-            <h2>Other Projects</h2>
-            <div class="project-grid">
-                <a href="omega-strikers.html" class="project">
-                    <div class="project-thumb" style="background-image: url('https://freight.cargo.site/w/100/i/V2548604313848078054190197947345/OmegaStrikersThumbnail.png'); background-size: cover; background-position: center;"></div>
-                    <div class="project-title">Omega Strikers</div>
-                </a>
-                <a href="chivalry-2.html" class="project">
-                    <div class="project-thumb" style="background-image: url('https://freight.cargo.site/w/100/i/J254858422750250841112505662417/Chivalry2Thumbnail.jpg'); background-size: cover; background-position: center;"></div>
-                    <div class="project-title">Chivalry 2</div>
-                </a>
-                <a href="warframe.html" class="project">
-                    <div class="project-thumb" style="background-image: url('https://freight.cargo.site/w/100/i/D2548583997102217360480205978577/WarframeThumbnail.jpg'); background-size: cover; background-position: center;"></div>
-                    <div class="project-title">Warframe</div>
-                </a>
-                <a href="amazing-eternals.html" class="project">
-                    <div class="project-thumb" style="background-image: url('https://freight.cargo.site/w/100/i/M2548583831192201161536498744273/TheAmazingEternals.jpg'); background-size: cover; background-position: center;"></div>
-                    <div class="project-title">Amazing Eternals</div>
-                </a>
-                <a href="field-1.html" class="project">
-                    <div class="project-thumb" style="background-image: url('https://freight.cargo.site/w/100/i/Z2548583629108119834048360790993/Field1Thumbnail.png'); background-size: cover; background-position: center;"></div>
-                    <div class="project-title">Field‑1</div>
-                </a>
-                <a href="zero-mark.html" class="project">
-                    <div class="project-thumb" style="background-image: url('https://freight.cargo.site/w/100/i/X254858340234224953936842775505/ZeroMarkThumbnail.png'); background-size: cover; background-position: center;"></div>
-                    <div class="project-title">Zero Mark</div>
-                </a>
-                <a href="witchball.html" class="project">
-                    <div class="project-thumb" style="background-image: url('https://freight.cargo.site/w/100/i/K2548580396334667660523149638609/wetwork_thumbnail.png'); background-size: cover; background-position: center;"></div>
-                    <div class="project-title">Witchball</div>
-                </a>
-                <a href="brutal-arena.html" class="project">
-                    <div class="project-thumb" style="background-image: url('https://freight.cargo.site/w/100/i/A25485818171410110770633735060433/BrutalArenaThumbnail.png'); background-size: cover; background-position: center;"></div>
-                    <div class="project-title">Brutal Arena</div>
-                </a>
-                <a href="index.html" class="project">
-                    <div class="project-thumb placeholder"></div>
-                    <div class="project-title">Back to Home</div>
-                </a>
-            </div>
-        </section>
+        <div class="page">
+            <section class="project-details">
+                <div class="project-meta">
+                    <b>Wetwork</b><br /><br />
+                    <span class="caption">CCG<br />2012</span>
+                </div>
+                <div class="project-body">
+                    <p>
+                        Wetwork is a two-player collectible card game where players must build their own spy organization and use them to dismantle their opponents' organization. Players may choose from one of three unique branch managers to build their organization around. These branch managers provide their organization with unique abilities that aid players in achieving their game goals.
+                    </p>
+                    <p>
+                        <b>Notable Mentions:</b><br />
+                        Included at the NYU Game Center's End of Year 2012 Showcase
+                    </p>
+                </div>
+            </section>
+            <section class="media-gallery">
+                <img src="assets/wetwork_thumbnail.png" alt="Wetwork screenshot 1" />
+                <img src="assets/wetwork_resource_mat.png" alt="Wetwork screenshot 2" />
+                <img src="assets/wetwork_rules_02_Page_2.png" alt="Wetwork screenshot 3" />
+                <img src="assets/vanilla_deck_Page_2.png" alt="Wetwork screenshot 4" />
+            </section>
+        </div>
     </main>
-    <footer class="footer">
-        <div class="footer-col">
-            <h3>Shervin Ghazazani</h3>
-            <ul class="contact-list">
-                <li><a href="mailto:shervinghazazani@gmail.com">Email</a></li>
-                <li><a href="#">LinkedIn</a></li>
-                <li><a href="#">Twitter</a></li>
-            </ul>
-        </div>
-        <div class="footer-col">
-            <h3>About Me</h3>
-            <p>
-                Hello and welcome to my portfolio! I'm a game designer at Odyssey
-                Interactive. My work tends to involve zero‑sum game systems,
-                fast‑paced dynamics, and visceral game feel.
-            </p>
-        </div>
-        <div class="footer-col">
-            <h3>Currently Consuming:</h3>
-            <ul>
-                <li>Witchfire (PC)</li>
-                <li>Dead Cells (iOS)</li>
-                <li>The Penguin (HBO)</li>
-                <li>3 Body Problem Trilogy (Audiobook)</li>
-            </ul>
+
+    <footer class="site-footer">
+        <div class="page">
+            <hr class="rule" />
+            <div class="footer-grid">
+                <div>
+                    <h3>Shervin Ghazazani</h3>
+                    <div class="caption footer-links">
+                        <a href="mailto:shervinghazazani@gmail.com">Email</a><br />
+                        <a href="https://www.linkedin.com/in/shervinghazazani/" target="_blank" rel="noreferrer">LinkedIn</a><br />
+                        <a href="https://www.twitter.com/gahzi" target="_blank" rel="noreferrer">Twitter</a>
+                    </div>
+                </div>
+                <div>
+                    <h3>About Me</h3>
+                    <div class="caption">
+                        Hello and welcome to my portfolio!<br /><br />
+                        I’m a game designer at Odyssey Interactive, specializing in competitive systems, fast-paced dynamics, and gameplay that feels immediately impactful.
+                    </div>
+                </div>
+                <div>
+                    <h3>Currently Consuming</h3>
+                    <div class="caption">
+                        - Witchfire (PC)<br />
+                        - Dead Cells (iOS)<br />
+                        - The Penguin (HBO)<br />
+                        - 3 Body Problem Trilogy (Audiobook)
+                    </div>
+                </div>
+            </div>
         </div>
     </footer>
 </body>

--- a/witchball.html
+++ b/witchball.html
@@ -7,100 +7,77 @@
     <link rel="stylesheet" href="style.css" />
 </head>
 <body>
-    <header>
-        <nav class="top-nav">
-            <a href="index.html#projects" class="nav-item">PROJECTS</a>
-            <div class="nav-title">
-                SHERVIN GHAZAZANI – TECHNICAL GAME DESIGNER
+    <header class="site-header">
+        <div class="page">
+            <div class="nav-grid">
+                <div class="nav-left">
+                    <a href="index.html#projects"><b><span class="caption">Projects</span></b></a>
+                </div>
+                <div class="nav-center">
+                    <b><span class="caption">Shervin Ghazazani - Technical Game Designer</span></b>
+                </div>
+                <div class="nav-right">
+                    <a href="mailto:shervinghazazani@gmail.com"><b><span class="caption">Contact</span></b></a>
+                </div>
             </div>
-            <a href="index.html#contact" class="nav-item">CONTACT</a>
-        </nav>
+            <hr class="rule" />
+        </div>
     </header>
+
     <main class="project-page">
-        <section class="project-content">
-            <h1>Witchball</h1>
-            <!-- Tagline and year -->
-            <p class="project-tagline">Pong‑like • 2013</p>
-            <div class="project-media"></div>
-            <p>A one‑button pong‑like game where two players battle in an ever‑changing ruleset.</p>
-            <p><strong>Notable Mentions:</strong></p>
-            <ul>
-                <li>Included in the NYU Game Center’s annual NO QUARTER exhibition</li>
-                <li>Featured in NY World Science Festival in 2013</li>
-            </ul>
-        </section>
-        <section class="project-screenshots">
-            <div class="screenshot-placeholder"></div>
-            <div class="screenshot-placeholder"></div>
-            <div class="screenshot-placeholder"></div>
-        </section>
-        <section class="project-grid-section">
-            <h2>Other Projects</h2>
-            <div class="project-grid">
-                <a href="omega-strikers.html" class="project">
-                    <div class="project-thumb" style="background-image: url('https://freight.cargo.site/w/100/i/V2548604313848078054190197947345/OmegaStrikersThumbnail.png'); background-size: cover; background-position: center;"></div>
-                    <div class="project-title">Omega Strikers</div>
-                </a>
-                <a href="chivalry-2.html" class="project">
-                    <div class="project-thumb" style="background-image: url('https://freight.cargo.site/w/100/i/J254858422750250841112505662417/Chivalry2Thumbnail.jpg'); background-size: cover; background-position: center;"></div>
-                    <div class="project-title">Chivalry 2</div>
-                </a>
-                <a href="warframe.html" class="project">
-                    <div class="project-thumb" style="background-image: url('https://freight.cargo.site/w/100/i/D2548583997102217360480205978577/WarframeThumbnail.jpg'); background-size: cover; background-position: center;"></div>
-                    <div class="project-title">Warframe</div>
-                </a>
-                <a href="amazing-eternals.html" class="project">
-                    <div class="project-thumb" style="background-image: url('https://freight.cargo.site/w/100/i/M2548583831192201161536498744273/TheAmazingEternals.jpg'); background-size: cover; background-position: center;"></div>
-                    <div class="project-title">Amazing Eternals</div>
-                </a>
-                <a href="field-1.html" class="project">
-                    <div class="project-thumb" style="background-image: url('https://freight.cargo.site/w/100/i/Z2548583629108119834048360790993/Field1Thumbnail.png'); background-size: cover; background-position: center;"></div>
-                    <div class="project-title">Field‑1</div>
-                </a>
-                <a href="zero-mark.html" class="project">
-                    <div class="project-thumb" style="background-image: url('https://freight.cargo.site/w/100/i/X254858340234224953936842775505/ZeroMarkThumbnail.png'); background-size: cover; background-position: center;"></div>
-                    <div class="project-title">Zero Mark</div>
-                </a>
-                <a href="wetwork.html" class="project">
-                    <div class="project-thumb" style="background-image: url('https://freight.cargo.site/w/100/i/K2548580396334667660523149638609/wetwork_thumbnail.png'); background-size: cover; background-position: center;"></div>
-                    <div class="project-title">Wetwork</div>
-                </a>
-                <a href="brutal-arena.html" class="project">
-                    <div class="project-thumb" style="background-image: url('https://freight.cargo.site/w/100/i/A25485818171410110770633735060433/BrutalArenaThumbnail.png'); background-size: cover; background-position: center;"></div>
-                    <div class="project-title">Brutal Arena</div>
-                </a>
-                <a href="index.html" class="project">
-                    <div class="project-thumb placeholder"></div>
-                    <div class="project-title">Back to Home</div>
-                </a>
-            </div>
-        </section>
+        <div class="page">
+            <section class="project-details">
+                <div class="project-meta">
+                    <b>Witchball</b><br /><br />
+                    <span class="caption">Pong-like<br />2013</span>
+                </div>
+                <div class="project-body">
+                    <p>A one-button pong-like game where two players battle in an ever-changing ruleset.</p>
+                    <p>
+                        <b>Notable Mentions:</b><br />
+                        - Included in the NYU Game Center's annual NO QUARTER exhibition.<br />
+                        - Featured in NY World Science Festival in 2013.
+                    </p>
+                </div>
+            </section>
+            <section class="media-gallery">
+                <img src="assets/Witchball1.png" alt="Witchball screenshot 1" />
+                <img src="assets/Witchball2.png" alt="Witchball screenshot 2" />
+                <img src="assets/Witchball4.png" alt="Witchball screenshot 3" />
+                <img src="assets/Witchball5.png" alt="Witchball screenshot 4" />
+            </section>
+        </div>
     </main>
-    <footer class="footer">
-        <div class="footer-col">
-            <h3>Shervin Ghazazani</h3>
-            <ul class="contact-list">
-                <li><a href="mailto:shervinghazazani@gmail.com">Email</a></li>
-                <li><a href="#">LinkedIn</a></li>
-                <li><a href="#">Twitter</a></li>
-            </ul>
-        </div>
-        <div class="footer-col">
-            <h3>About Me</h3>
-            <p>
-                Hello and welcome to my portfolio! I'm a game designer at Odyssey
-                Interactive. My work tends to involve zero‑sum game systems,
-                fast‑paced dynamics, and visceral game feel.
-            </p>
-        </div>
-        <div class="footer-col">
-            <h3>Currently Consuming:</h3>
-            <ul>
-                <li>Witchfire (PC)</li>
-                <li>Dead Cells (iOS)</li>
-                <li>The Penguin (HBO)</li>
-                <li>3 Body Problem Trilogy (Audiobook)</li>
-            </ul>
+
+    <footer class="site-footer">
+        <div class="page">
+            <hr class="rule" />
+            <div class="footer-grid">
+                <div>
+                    <h3>Shervin Ghazazani</h3>
+                    <div class="caption footer-links">
+                        <a href="mailto:shervinghazazani@gmail.com">Email</a><br />
+                        <a href="https://www.linkedin.com/in/shervinghazazani/" target="_blank" rel="noreferrer">LinkedIn</a><br />
+                        <a href="https://www.twitter.com/gahzi" target="_blank" rel="noreferrer">Twitter</a>
+                    </div>
+                </div>
+                <div>
+                    <h3>About Me</h3>
+                    <div class="caption">
+                        Hello and welcome to my portfolio!<br /><br />
+                        I’m a game designer at Odyssey Interactive, specializing in competitive systems, fast-paced dynamics, and gameplay that feels immediately impactful.
+                    </div>
+                </div>
+                <div>
+                    <h3>Currently Consuming</h3>
+                    <div class="caption">
+                        - Witchfire (PC)<br />
+                        - Dead Cells (iOS)<br />
+                        - The Penguin (HBO)<br />
+                        - 3 Body Problem Trilogy (Audiobook)
+                    </div>
+                </div>
+            </div>
         </div>
     </footer>
 </body>

--- a/zero-mark.html
+++ b/zero-mark.html
@@ -7,97 +7,82 @@
     <link rel="stylesheet" href="style.css" />
 </head>
 <body>
-    <header>
-        <nav class="top-nav">
-            <a href="index.html#projects" class="nav-item">PROJECTS</a>
-            <div class="nav-title">
-                SHERVIN GHAZAZANI – TECHNICAL GAME DESIGNER
+    <header class="site-header">
+        <div class="page">
+            <div class="nav-grid">
+                <div class="nav-left">
+                    <a href="index.html#projects"><b><span class="caption">Projects</span></b></a>
+                </div>
+                <div class="nav-center">
+                    <b><span class="caption">Shervin Ghazazani - Technical Game Designer</span></b>
+                </div>
+                <div class="nav-right">
+                    <a href="mailto:shervinghazazani@gmail.com"><b><span class="caption">Contact</span></b></a>
+                </div>
             </div>
-            <a href="index.html#contact" class="nav-item">CONTACT</a>
-        </nav>
+            <hr class="rule" />
+        </div>
     </header>
+
     <main class="project-page">
-        <section class="project-content">
-            <h1>Zero Mark</h1>
-            <!-- Tagline and year -->
-            <p class="project-tagline">Fermentu • 2014</p>
-            <div class="project-media"></div>
-            <p>Zero.Mark is a team‑based multiplayer arena shooter featuring a unique scoring mechanic. Players can choose from one of three character classes and earn points by defeating their opponents in combat. As players gain points, they become stronger but will also lose them on death. Winning in Zero.Mark is about balancing risk vs reward in combat while timing your deposits with your teammates.</p>
-            <p><strong>Notable Mentions:</strong> Included at the NYU Game Center’s End of Year Showcase</p>
-            <p><strong>Website:</strong> <a href="https://gahzi.github.io/ZeroMark/">https://gahzi.github.io/ZeroMark/</a></p>
-        </section>
-        <section class="project-screenshots">
-            <div class="screenshot-placeholder"></div>
-            <div class="screenshot-placeholder"></div>
-            <div class="screenshot-placeholder"></div>
-        </section>
-        <section class="project-grid-section">
-            <h2>Other Projects</h2>
-            <div class="project-grid">
-                <a href="omega-strikers.html" class="project">
-                    <div class="project-thumb" style="background-image: url('https://freight.cargo.site/w/100/i/V2548604313848078054190197947345/OmegaStrikersThumbnail.png'); background-size: cover; background-position: center;"></div>
-                    <div class="project-title">Omega Strikers</div>
-                </a>
-                <a href="chivalry-2.html" class="project">
-                    <div class="project-thumb" style="background-image: url('https://freight.cargo.site/w/100/i/J254858422750250841112505662417/Chivalry2Thumbnail.jpg'); background-size: cover; background-position: center;"></div>
-                    <div class="project-title">Chivalry 2</div>
-                </a>
-                <a href="warframe.html" class="project">
-                    <div class="project-thumb" style="background-image: url('https://freight.cargo.site/w/100/i/D2548583997102217360480205978577/WarframeThumbnail.jpg'); background-size: cover; background-position: center;"></div>
-                    <div class="project-title">Warframe</div>
-                </a>
-                <a href="amazing-eternals.html" class="project">
-                    <div class="project-thumb" style="background-image: url('https://freight.cargo.site/w/100/i/M2548583831192201161536498744273/TheAmazingEternals.jpg'); background-size: cover; background-position: center;"></div>
-                    <div class="project-title">Amazing Eternals</div>
-                </a>
-                <a href="field-1.html" class="project">
-                    <div class="project-thumb" style="background-image: url('https://freight.cargo.site/w/100/i/Z2548583629108119834048360790993/Field1Thumbnail.png'); background-size: cover; background-position: center;"></div>
-                    <div class="project-title">Field‑1</div>
-                </a>
-                <a href="witchball.html" class="project">
-                    <div class="project-thumb" style="background-image: url('https://freight.cargo.site/w/100/i/K2548580396334667660523149638609/wetwork_thumbnail.png'); background-size: cover; background-position: center;"></div>
-                    <div class="project-title">Witchball</div>
-                </a>
-                <a href="wetwork.html" class="project">
-                    <div class="project-thumb" style="background-image: url('https://freight.cargo.site/w/100/i/K2548580396334667660523149638609/wetwork_thumbnail.png'); background-size: cover; background-position: center;"></div>
-                    <div class="project-title">Wetwork</div>
-                </a>
-                <a href="brutal-arena.html" class="project">
-                    <div class="project-thumb" style="background-image: url('https://freight.cargo.site/w/100/i/A25485818171410110770633735060433/BrutalArenaThumbnail.png'); background-size: cover; background-position: center;"></div>
-                    <div class="project-title">Brutal Arena</div>
-                </a>
-                <a href="index.html" class="project">
-                    <div class="project-thumb placeholder"></div>
-                    <div class="project-title">Back to Home</div>
-                </a>
-            </div>
-        </section>
+        <div class="page">
+            <section class="project-details">
+                <div class="project-meta">
+                    <b>Zero.Mark</b><br /><br />
+                    <span class="caption">Fermentu<br />2014</span>
+                </div>
+                <div class="project-body">
+                    <p>
+                        Zero.Mark is a team-based multiplayer arena shooter featuring a unique scoring mechanic. Players can choose from one of three character classes and earn points by defeating their opponents in combat. As players gain points, they become stronger but will also lose them on death. Winning in Zero.Mark is about balancing risk vs reward in combat while timing your deposits with your teammates.
+                    </p>
+                    <p>
+                        <b>Notable Mentions:</b><br />
+                        Included at the NYU Game Center's End of Year Showcase
+                    </p>
+                    <p>
+                        <b>Website</b><br />
+                        <a href="https://gahzi.github.io/ZeroMark/" target="_blank" rel="noreferrer">https://gahzi.github.io/ZeroMark/</a>
+                    </p>
+                </div>
+            </section>
+            <section class="media-gallery">
+                <img src="assets/test_600.jpg" alt="Zero Mark screenshot 1" />
+                <img src="assets/TTT_500.png" alt="Zero Mark screenshot 2" />
+                <img src="assets/tumblr_n3udviTCwl1shf3nvo4_500.png" alt="Zero Mark screenshot 3" />
+                <img src="assets/2013-05-16-20.33.46.jpg" alt="Zero Mark screenshot 4" />
+            </section>
+        </div>
     </main>
-    <footer class="footer">
-        <div class="footer-col">
-            <h3>Shervin Ghazazani</h3>
-            <ul class="contact-list">
-                <li><a href="mailto:shervinghazazani@gmail.com">Email</a></li>
-                <li><a href="#">LinkedIn</a></li>
-                <li><a href="#">Twitter</a></li>
-            </ul>
-        </div>
-        <div class="footer-col">
-            <h3>About Me</h3>
-            <p>
-                Hello and welcome to my portfolio! I'm a game designer at Odyssey
-                Interactive. My work tends to involve zero‑sum game systems,
-                fast‑paced dynamics, and visceral game feel.
-            </p>
-        </div>
-        <div class="footer-col">
-            <h3>Currently Consuming:</h3>
-            <ul>
-                <li>Witchfire (PC)</li>
-                <li>Dead Cells (iOS)</li>
-                <li>The Penguin (HBO)</li>
-                <li>3 Body Problem Trilogy (Audiobook)</li>
-            </ul>
+
+    <footer class="site-footer">
+        <div class="page">
+            <hr class="rule" />
+            <div class="footer-grid">
+                <div>
+                    <h3>Shervin Ghazazani</h3>
+                    <div class="caption footer-links">
+                        <a href="mailto:shervinghazazani@gmail.com">Email</a><br />
+                        <a href="https://www.linkedin.com/in/shervinghazazani/" target="_blank" rel="noreferrer">LinkedIn</a><br />
+                        <a href="https://www.twitter.com/gahzi" target="_blank" rel="noreferrer">Twitter</a>
+                    </div>
+                </div>
+                <div>
+                    <h3>About Me</h3>
+                    <div class="caption">
+                        Hello and welcome to my portfolio!<br /><br />
+                        I’m a game designer at Odyssey Interactive, specializing in competitive systems, fast-paced dynamics, and gameplay that feels immediately impactful.
+                    </div>
+                </div>
+                <div>
+                    <h3>Currently Consuming</h3>
+                    <div class="caption">
+                        - Witchfire (PC)<br />
+                        - Dead Cells (iOS)<br />
+                        - The Penguin (HBO)<br />
+                        - 3 Body Problem Trilogy (Audiobook)
+                    </div>
+                </div>
+            </div>
         </div>
     </footer>
 </body>


### PR DESCRIPTION
### Motivation
- Fix PR creation failures caused by binary image diffs by moving portfolio images under Git LFS management.  
- Serve the static site from local `assets/` files instead of remote freight URLs for a self‑contained site.  
- Centralize layout and styling for consistent pages via `style.css` updates.  

### Description
- Added `.gitattributes` to track `assets/*.jpg` and `assets/*.png` and ran `git lfs track` to enable LFS for image files.  
- Converted assets in `assets/` to LFS pointers and committed the metadata so images are now LFS‑managed.  
- Reworked page templates across `index.html`, per‑project pages (for example `amazing-eternals.html`, `omega-strikers.html`, `chivalry-2.html`, `brutal-arena.html`, `field-1.html`, `warframe.html`, `wetwork.html`, `witchball.html`, `zero-mark.html`) to reference local `assets/` thumbnails and media and update header/footer layout.  
- Refactored `style.css` to add a responsive grid, page container classes, and unified header/footer styles.  

### Testing
- Verified `git lfs version` returned a valid LFS client and `git lfs track` successfully updated tracking, both commands succeeded.  
- Used `git show :assets/OmegaStrikers1.jpg` to confirm the file is an LFS pointer (pointer metadata present), which succeeded.  
- Performed `git rm --cached assets/*` and `git add .gitattributes assets` then committed with `git commit` which completed successfully.  
- No automated unit tests applicable to static content changes were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696450db60d8832ebb47820c54282ddb)